### PR TITLE
90% - LIG-476 - Separating Persona validation from http interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var PersonaClient = function (config) {
     this.config = config || {};
 
     var requiredAttributes = [
-        'persona_host', 'persona_port', 'persona_schema',
+        'persona_host', 'persona_port', 'persona_scheme',
         'persona_oauth_route', 'redis_host', 'redis_port',
         'redis_db'
     ];

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ PersonaClient.prototype.validateBearerToken = function(token, scope, overridingS
                     }
                 }
             }).on("error", function (e) {
-                _this.error("OAuth::validateToken problem: " + err.message);
+                _this.error("OAuth::validateToken problem: " + e.message);
                 next(e.message);
             }).end();
         }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ var cryptojs = require('crypto-js'),
 var DEBUG = "debug";
 var ERROR = "error";
 
+var ERROR_TYPES = {
+    VALIDATION_FAILURE : "validation_failure",
+    COMMUNICATION_ISSUE :"communication_issue",
+    INVALID_TOKEN : "invalid_token"
+};
+
 /**
  * Constructor you must pass in a config object with the following properties set:
  *
@@ -34,30 +40,19 @@ var ERROR = "error";
 var PersonaClient = function (config) {
     this.config = config || {};
 
-    //TODO: find a less verbose way of doing this
+    var requiredAttributes = [
+        'persona_host', 'persona_port', 'persona_schema',
+        'persona_oauth_route', 'redis_host', 'redis_port',
+        'redis_db'
+    ];
 
-    if (this.config.persona_host === undefined) {
-        throw new Error("You must specify the Persona server host");
-    }
-    if (this.config.persona_port === undefined) {
-        throw new Error("You must specify the Persona server port");
-    }
-    if (this.config.persona_scheme === undefined) {
-        throw new Error("You must specify the Persona server scheme (http/https)");
-    }
-    if (this.config.persona_oauth_route === undefined) {
-        throw new Error("You must specify the Persona oauth route");
+    for (var attribute in requiredAttributes) {
+        if (this.config[attribute] === undefined) {
+            var name = attribute.replace(/_/g, ' ');
+            throw new Error("You must specify the " + name);
+        }
     }
 
-    if (this.config.redis_host === undefined) {
-        throw new Error("You must specify the Redis host to use as a cache");
-    }
-    if (this.config.redis_port === undefined) {
-        throw new Error("You must specify the Redis port");
-    }
-    if (this.config.redis_db === undefined) {
-        throw new Error("You must specify the Redis db");
-    }
     // connect to redis and switch to the configured db
     var redis = require('redis');
     this.redisClient = redis.createClient(this.config.redis_port, this.config.redis_host);
@@ -69,41 +64,26 @@ var PersonaClient = function (config) {
     this.debug("Persona Client Created");
 };
 
-/**
- * Express middleware that can be used to verify a token
- * @param req
- * @param res
- * @param next
- */
-PersonaClient.prototype.validateToken = function (req, res, next, scope) {
-    var token = this.getToken(req),
-        _this = this;
-
+PersonaClient.prototype.validateBearerToken = function(token, scope, overridingScope, next) {
     if (token == null) {
-        res.status(401);
-        res.json({
-            "error": "no_token",
-            "error_description": "No token supplied"
-        });
-        throw "OAuth validation failed for " + token;
+        next(ERROR_TYPES.INVALID_TOKEN);
+        return;
     }
+
+    var _this = this;
 
     // if we were given a scope then append the scope to the token to create a cachekey
-    var cacheKey = token;
-    if (req.param("scope")) {
-        cacheKey += "@" + req.param("scope");
-    }
-
+    var cacheKey = token + ((scope) ? "@" + scope : "");
     this.debug("Validating token: " + cacheKey);
 
     this.redisClient.get("access_token:" + cacheKey, function (err, reply) {
         if (reply === "OK") {
             _this.debug("Token " + cacheKey + " verified by cache");
-            next(null, "verified_by_cache");
+            next(null);
         } else {
-
             var requestPath = _this.config.persona_oauth_route + token;
-            var usingScope = scope || req.param("scope") || null;
+            var usingScope = scope || overridingScope || null;
+
             if (usingScope != null) {
                 requestPath += "?scope=" + usingScope;
             }
@@ -116,6 +96,7 @@ PersonaClient.prototype.validateToken = function (req, res, next, scope) {
             };
 
             _this.debug(JSON.stringify(options));
+
             _this.http.request(options, function (oauthResp) {
                 if (oauthResp.statusCode === 204) {
                     // put this key in redis with an expire
@@ -123,33 +104,67 @@ PersonaClient.prototype.validateToken = function (req, res, next, scope) {
                         _this.debug("cache: " + JSON.stringify(err) + JSON.stringify(results));
                     });
                     _this.debug("Verification passed for token " + cacheKey + ", cached for 60s");
-                    next(null, "verified_by_persona");
+                    next(null);
                 } else {
                     if (usingScope && usingScope !== "su") {
                         // try su, they are allowed to perform any operation
-                        _this.validateToken(req,res,next,"su");
+                        _this.validateBearerToken(token, "su", overridingScope, next);
                     } else {
                         _this.debug("Verification failed for token " + cacheKey + " with status code " + oauthResp.statusCode);
-                        res.status(401);
-                        res.set("Connection", "close");
-                        res.json({
-                            "error": "invalid_token",
-                            "error_description": "The token is invalid or has expired"
-                        });
+                        next(ERROR_TYPES.VALIDATION_FAILURE);
                     }
                 }
             }).on("error", function (e) {
-                _this.error("OAuth::validateToken problem: " + e.message);
-                res.status(500);
-                res.set("Connection", "close");
-                res.json({
-                    "error": "unexpected_error",
-                    "error_description": e.message
-                });
+                _this.error("OAuth::validateToken problem: " + err.message);
+                next(e.message);
             }).end();
         }
     });
+};
 
+/**
+ * Express middleware that can be used to verify a token
+ * @param req
+ * @param res
+ * @param next
+ */
+PersonaClient.prototype.validateToken = function (req, res, next, scope) {
+    var token = this.getToken(req);
+
+    this.validateBearerToken(token, req.param("scope"), scope, function(err) {
+        if (!err) {
+            // TODO: do we need a success msg?
+            // TODO: does the other end need to know if it was cache or not?
+            next(null, "verified_by_persona");
+            return;
+        }
+
+        switch(err) {
+        case ERROR_TYPES.INVALID_TOKEN:
+            res.status(401);
+            res.json({
+                "error": "no_token",
+                "error_description": "No token supplied"
+            });
+
+            throw "OAuth validation failed for " + token;
+        case ERROR_TYPES.VALIDATION_FAILURE:
+            res.status(401);
+            res.set("Connection", "close");
+            res.json({
+                "error": "invalid_token",
+                "error_description": "The token is invalid or has expired"
+            });
+            break;
+        default:
+            res.status(500);
+            res.set("Connection", "close");
+            res.json({
+                "error": "unexpected_error",
+                "error_description": err
+            });
+        }
+    });
 };
 
 /**
@@ -329,7 +344,7 @@ PersonaClient.prototype.obtainToken = function (id, secret, callback) {
                                 // cache token
                                 var cacheFor = data.expires_in - 60, // cache for token validity minus 60s
                                     now = (new Date().getTime() / 1000);
-                                data['expires_at'] = now + data.expires_in;
+                                data.expires_at = now + data.expires_in;
                                 if (cacheFor > 0) {
                                     _this.redisClient.multi().set(cacheKey, JSON.stringify(data)).expire(cacheKey, cacheFor).exec(function (err) {
                                         if (err) {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ var PersonaClient = function (config) {
         'redis_db'
     ];
 
-    for (var attribute in requiredAttributes) {
+    for (var i = 0; i < requiredAttributes.length; i++) {
+        var attribute = requiredAttributes[i];
+
         if (this.config[attribute] === undefined) {
             var name = attribute.replace(/_/g, ' ');
             throw new Error("You must specify the " + name);

--- a/index.js
+++ b/index.js
@@ -79,17 +79,20 @@ var PersonaClient = function (config) {
  * @param next: Callback, function(err, validatedBy)
  */
 PersonaClient.prototype.validateToken = function (token, scope, overridingScope, next) {
+    if (!next) {
+        throw "No callback (next attribute) provided";
+    }
+
     if (token == null) {
         next(ERROR_TYPES.INVALID_TOKEN, null);
         return;
     }
 
-    var _this = this;
-
+    var _this = this,
+        cacheKey = token + ((scope) ? "@" + scope : "");
     // if we were given a scope then append the scope to the token to create a cachekey
-    var cacheKey = token + ((scope) ? "@" + scope : "");
-    this.debug("Validating token: " + cacheKey);
 
+    this.debug("Validating token: " + cacheKey);
     this.redisClient.get("access_token:" + cacheKey, function (err, reply) {
         if (reply === "OK") {
             _this.debug("Token " + cacheKey + " verified by cache");

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-use strict';
+"use strict";
 
 var cryptojs = require('crypto-js'),
     url = require('url'),
@@ -145,7 +145,7 @@ PersonaClient.prototype.validateToken = function (token, scope, overridingScope,
 PersonaClient.prototype.validateHTTPBearerToken = function (req, res, next, scope) {
     var token = this.getToken(req);
 
-    this.validateBearerToken(token, req.param("scope"), scope, function (err, validatedBy) {
+    this.validateToken(token, req.param("scope"), scope, function (err, validatedBy) {
         if (!err) {
             next(null, validatedBy);
             return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": 1.0.0",
+  "version": "1.0.0",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "0.4.0",
+  "version": 1.0.0",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",

--- a/test/persona_client_test.js
+++ b/test/persona_client_test.js
@@ -19,14 +19,14 @@ describe("Persona Client Test Suite", function(){
             var personaClient = function(){
                 return persona.createClient({});
             };
-            personaClient.should.throw("You must specify the Persona server host");
+            personaClient.should.throw("You must specify the persona host");
             done();
         });
         it("should throw error if config.persona_port is not supplied", function(done){
             var personaClient = function(){
                 return persona.createClient({persona_host:"persona"});
             };
-            personaClient.should.throw("You must specify the Persona server port");
+            personaClient.should.throw("You must specify the persona port");
             done();
         });
         it("should throw error if config.persona_scheme is not supplied", function(done){
@@ -36,7 +36,7 @@ describe("Persona Client Test Suite", function(){
                     persona_port:80
                 });
             };
-            personaClient.should.throw("You must specify the Persona server scheme (http/https)");
+            personaClient.should.throw("You must specify the persona scheme");
             done();
         });
         it("should throw error if config.persona_oauth_route is not supplied", function(done){
@@ -47,7 +47,7 @@ describe("Persona Client Test Suite", function(){
                     persona_scheme:"http"
                 });
             };
-            personaClient.should.throw("You must specify the Persona oauth route");
+            personaClient.should.throw("You must specify the persona oauth route");
             done();
         });
         it("should throw error if config.redis_host is not supplied", function(done){
@@ -59,7 +59,7 @@ describe("Persona Client Test Suite", function(){
                     persona_oauth_route:"/oauth/tokens"
                 });
             };
-            personaClient.should.throw("You must specify the Redis host to use as a cache");
+            personaClient.should.throw("You must specify the redis host");
             done();
         });
         it("should throw error if config.redis_port is not supplied", function(done){
@@ -72,7 +72,7 @@ describe("Persona Client Test Suite", function(){
                     redis_host:"persona"
                 });
             };
-            personaClient.should.throw("You must specify the Redis port");
+            personaClient.should.throw("You must specify the redis port");
             done();
         });
         it("should throw error if config.redis_db is not supplied", function(done){
@@ -86,7 +86,7 @@ describe("Persona Client Test Suite", function(){
                     redis_port:6379
                 });
             };
-            personaClient.should.throw("You must specify the Redis db");
+            personaClient.should.throw("You must specify the redis db");
             done();
         });
         it("should NOT throw any error if all config params are defined", function(done){

--- a/test/persona_client_test.js
+++ b/test/persona_client_test.js
@@ -528,7 +528,7 @@ describe("Persona Client Test Suite", function(){
             // the callback wont be called internally because this is middleware
             // therefore we need to call validate token and wait a couple of seconds for the
             // request to fail and asser the response object
-            personaClient.validateToken(req, res, null);
+            personaClient.validateHTTPBearerToken(req, res, null);
             setTimeout(function(){
                 res._statusWasCalled.should.equal(true);
                 res._jsonWasCalled.should.equal(true);
@@ -558,7 +558,7 @@ describe("Persona Client Test Suite", function(){
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
 
-                personaClient.validateToken(req, res, function(err, result){
+                personaClient.validateHTTPBearerToken(req, res, function(err, result){
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -586,7 +586,7 @@ describe("Persona Client Test Suite", function(){
                 var req = _getStubRequest(token, "primate");
                 var res = _getStubResponse();
 
-                personaClient.validateToken(req, res, function(err, result){
+                personaClient.validateHTTPBearerToken(req, res, function(err, result){
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -617,7 +617,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, null);
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, function(err, result){
+                        personaClient.validateHTTPBearerToken(req, res, function(err, result){
                             assert.equal(res._statusWasCalled, false);
                             assert.equal(res._jsonWasCalled, false);
                             assert.equal(res._setWasCalled, false);
@@ -631,7 +631,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, null);
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, function(err, result){
+                        personaClient.validateHTTPBearerToken(req, res, function(err, result){
                             assert.equal(res._statusWasCalled, false);
                             assert.equal(res._jsonWasCalled, false);
                             assert.equal(res._setWasCalled, false);
@@ -668,7 +668,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, "primate");
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, function(err, result){
+                        personaClient.validateHTTPBearerToken(req, res, function(err, result){
                             assert.equal(res._statusWasCalled, false);
                             assert.equal(res._jsonWasCalled, false);
                             assert.equal(res._setWasCalled, false);
@@ -682,7 +682,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, "primate");
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, function(err, result){
+                        personaClient.validateHTTPBearerToken(req, res, function(err, result){
                             if(err) return callback(err);
 
                             assert.equal(res._statusWasCalled, false);
@@ -721,7 +721,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, "primate");
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, function(err, result){
+                        personaClient.validateHTTPBearerToken(req, res, function(err, result){
                             assert.equal(res._statusWasCalled, false);
                             assert.equal(res._jsonWasCalled, false);
                             assert.equal(res._setWasCalled, false);
@@ -735,7 +735,7 @@ describe("Persona Client Test Suite", function(){
                         var req = _getStubRequest(token, "wibble");
                         var res = _getStubResponse();
 
-                        personaClient.validateToken(req, res, null);
+                        personaClient.validateHTTPBearerToken(req, res, null);
                         setTimeout(function(){
                             res._statusWasCalled.should.equal(true);
                             res._jsonWasCalled.should.equal(true);


### PR DESCRIPTION
The validate token function was bound heavily to the http
request and response objects as it was originally used as
middleware for a http server.

This commit separates the http request and response objects
from the validation of a bearer.

JFDI: found a shorter way of checking the configuration object
for all attributes required.