### PR TITLE
Remove throwing of exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Node Client for Persona, responsible for retrieving, generating, caching and val
 Install the module by adding the following line to `packages.json`: 
 
 ```
-    "persona_client": "git://github.com/talis/persona-node-client.git#1.1.0"
+    "persona_client": "git://github.com/talis/persona-node-client.git#1.1.1"
 ```
 
 Create a persona client as follows:
@@ -112,6 +112,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+* 1.1.1 - Remove exception that was thrown when the oauth token was invalid. The HTTP status and body is now set as expected.
 * 1.1.0 - Added methods for getting and updating a user profile
 * 1.0.0 - Breaking change to existing functionality: The method validateToken is now called validateHTTPBearerToken. The validateToken method validates a token against Persona, while the validateHTTPBearerToken method validates a token that originates from a http call (one of the attributes required is a http request object).
 * 0.3.0 - added the ability to request/delete client authorizations, and fixed scoping issue on validation.

--- a/index.js
+++ b/index.js
@@ -161,8 +161,7 @@ PersonaClient.prototype.validateHTTPBearerToken = function (req, res, next, scop
                 "error": "no_token",
                 "error_description": "No token supplied"
             });
-
-            throw "OAuth validation failed for " + token;
+            break;
         case ERROR_TYPES.VALIDATION_FAILURE:
             res.status(401);
             res.set("Connection", "close");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",


### PR DESCRIPTION
Weirdly 2 out of the three errors that can throw an exception when validating a token return a callback with a error. One of them however throws an exception. While tinkering with a set of middleware in TN the exception started to cause problems. When the exception was thrown it would cause the error to response with a empty http response.