### PR TITLE
90%: Platform 137 make redis optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Node Client for Persona, responsible for retrieving, generating, caching and validating OAuth Tokens.
 
 ## Getting Started
-Install the module by adding the following line to `packages.json`: 
+Install the module by adding the following line to `packages.json`:
 
 ```
     "persona_client": "git://github.com/talis/persona-node-client.git#1.3.0"
@@ -18,9 +18,6 @@ var personaClient = persona.createClient({
     persona_port:443,
     persona_scheme:"https",
     persona_oauth_route:"/oauth/tokens",
-    redis_host:"localhost",
-    redis_port:6379,
-    redis_db:0,
     enable_debug: true,
     logger: AppLogger
 });
@@ -57,7 +54,7 @@ If the validation fails, `401` will be returned to the client automatically.
 
 ### Pre-signing signing urls
 
-Signing: 
+Signing:
 
 ```javascript
   personaClient.presignUrl('http://url.to.sign/','mySecret',secsSinceEpocToExpiry,function(err,signedUrl) {
@@ -73,7 +70,7 @@ Checking:
 
 ### Client authorizations
 
-Requesting: 
+Requesting:
 
 ```javascript
   personaClient.requestAuthorization('user_guid', 'Required for access to admin', 'client_id', 'client_secret', function(err,authorization) {
@@ -108,6 +105,35 @@ Via guid:
     var profile = user.profile;
   });
 ```
+
+### Caching OAuth tokens
+
+Persona client allows multiple strategies to cache tokens (to avoid repeated
+ requests to Persona) via [cache-service](https://npmjs.org/package/cache-service)
+
+ This is configured through the persona client config, e.g.:
+
+ ```javascript
+ {
+     persona_host:"localhost",
+     persona_port:443,
+     persona_scheme:"https",
+     persona_oauth_route:"/oauth/tokens",
+     cache: {
+       module: "redis",
+       options: {
+         redisData: {
+           hostname: "localhost",
+           port: 6379
+         }
+       }
+     },
+     enable_debug: true,
+     logger: AppLogger
+ ```
+
+ `module` corresponds to any cache-service module: e.g. "redis" would require
+ `cache-service-redis`.  By default, it will use an in-memory cache (`node-cache`).
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,40 +1,72 @@
 {
   "name": "persona_client",
-  "version": "2.0.0",
+  "version": "1.3.0",
   "dependencies": {
     "async": {
       "version": "0.2.10",
-      "from": "async@~0.2.9"
+      "from": "async@~0.2.9",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+    },
+    "cache-service": {
+      "version": "1.3.5",
+      "from": "cache-service@1.3.5",
+      "resolved": "https://registry.npmjs.org/cache-service/-/cache-service-1.3.5.tgz",
+      "dependencies": {
+        "cache-service-cache-module": {
+          "version": "1.2.3",
+          "from": "cache-service-cache-module@1.2.3",
+          "resolved": "https://registry.npmjs.org/cache-service-cache-module/-/cache-service-cache-module-1.2.3.tgz"
+        }
+      }
+    },
+    "cache-service-node-cache": {
+      "version": "1.1.1",
+      "from": "cache-service-node-cache@1.1.1",
+      "resolved": "https://registry.npmjs.org/cache-service-node-cache/-/cache-service-node-cache-1.1.1.tgz",
+      "dependencies": {
+        "node-cache": {
+          "version": "2.1.1",
+          "from": "node-cache@2.1.1",
+          "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-2.1.1.tgz"
+        }
+      }
+    },
+    "cache-service-redis": {
+      "version": "1.1.3",
+      "from": "cache-service-redis@1.1.3",
+      "resolved": "https://registry.npmjs.org/cache-service-redis/-/cache-service-redis-1.1.3.tgz",
+      "dependencies": {
+        "redis": {
+          "version": "0.12.1",
+          "from": "redis@0.12.1",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
+        }
+      }
     },
     "crypto-js": {
       "version": "3.1.2-2",
       "from": "crypto-js@3.1.2-2",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.2-2.tgz"
     },
-    "lodash": {
-      "version": "3.10.1",
-      "from": "lodash@3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-    },
-    "redis": {
-      "version": "0.9.2",
-      "from": "redis@~0.9.1"
-    },
     "jsonwebtoken": {
       "version": "5.7.0",
       "from": "jsonwebtoken@~5.7.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
       "dependencies": {
         "jws": {
           "version": "3.1.3",
           "from": "jws@^3.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
           "dependencies": {
             "base64url": {
               "version": "1.0.6",
               "from": "base64url@~1.0.4",
+              "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.10",
                   "from": "concat-stream@~1.4.7",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -43,15 +75,18 @@
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5"
+                      "from": "typedarray@~0.0.5",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@~1.0.0"
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
@@ -60,7 +95,8 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x"
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     }
@@ -69,36 +105,49 @@
                 "meow": {
                   "version": "2.0.0",
                   "from": "meow@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
-                      "version": "2.0.0",
+                      "version": "1.0.0",
                       "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "2.1.0",
-                          "from": "camelcase@^2.0.0"
+                          "version": "1.2.1",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@^1.0.0"
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "2.1.0",
+                      "version": "1.2.2",
                       "from": "indent-string@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@^4.0.1",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
                         "repeating": {
-                          "version": "2.0.0",
-                          "from": "repeating@^2.0.0",
+                          "version": "1.1.3",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
                               "from": "is-finite@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@^1.0.0"
+                                  "from": "number-is-nan@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
                             }
@@ -108,11 +157,13 @@
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@^1.1.0"
+                      "from": "minimist@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "object-assign": {
-                      "version": "4.0.1",
-                      "from": "object-assign@^1.0.0"
+                      "version": "1.0.0",
+                      "from": "object-assign@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                     }
                   }
                 }
@@ -125,11 +176,13 @@
               "dependencies": {
                 "buffer-equal-constant-time": {
                   "version": "1.0.1",
-                  "from": "buffer-equal-constant-time@^1.0.1"
+                  "from": "buffer-equal-constant-time@^1.0.1",
+                  "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                 },
                 "ecdsa-sig-formatter": {
                   "version": "1.0.5",
                   "from": "ecdsa-sig-formatter@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
                   "dependencies": {
                     "base64-url": {
                       "version": "1.2.1",
@@ -144,31 +197,43 @@
         },
         "ms": {
           "version": "0.7.1",
-          "from": "ms@^0.7.1"
+          "from": "ms@^0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@^4.0.1"
+          "from": "xtend@^4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
+    "lodash": {
+      "version": "3.10.1",
+      "from": "lodash@3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+    },
     "should": {
       "version": "3.3.2",
-      "from": "should@3.3.2",
-      "resolved": "https://registry.npmjs.org/should/-/should-3.3.2.tgz"
+      "from": "should@~3.3.2"
+    },
+    "leche": {
+      "version": "2.1.1",
+      "from": "leche@"
     },
     "sinon": {
-      "version": "1.9.1",
-      "from": "sinon@1.9.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.9.1.tgz",
+      "version": "1.12.1",
+      "from": "sinon@1.12.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.12.1.tgz",
       "dependencies": {
         "formatio": {
-          "version": "1.0.2",
-          "from": "formatio@~1.0",
+          "version": "1.1.3",
+          "from": "formatio@~1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.3.tgz",
           "dependencies": {
             "samsam": {
-              "version": "1.1.3",
-              "from": "samsam@~1.1"
+              "version": "1.2.1",
+              "from": "samsam@1.x",
+              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
             }
           }
         },
@@ -178,16 +243,102 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "from": "lolex@1.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
+        }
+      }
+    },
+    "nock": {
+      "version": "7.2.2",
+      "from": "nock@~7.2.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-7.2.2.tgz",
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "from": "chai@>=1.9.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "dependencies": {
+            "assertion-error": {
+              "version": "1.0.1",
+              "from": "assertion-error@^1.0.1",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "from": "deep-eql@^0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "from": "type-detect@0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                }
+              }
+            },
+            "type-detect": {
+              "version": "1.0.0",
+              "from": "type-detect@^1.0.0",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@*",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "from": "deep-equal@^1.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@^5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@^0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "propagate": {
+          "version": "0.3.1",
+          "from": "propagate@0.3.x",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+        },
+        "qs": {
+          "version": "6.1.0",
+          "from": "qs@^6.0.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         }
       }
     },
     "mocha": {
-      "version": "1.14.0",
-      "from": "mocha@~1.14.0",
+      "version": "1.18.2",
+      "from": "mocha@~1.18.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz",
       "dependencies": {
         "commander": {
           "version": "2.0.0",
@@ -210,8 +361,7 @@
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+              "from": "mkdirp@0.3.0"
             }
           }
         },
@@ -222,12 +372,11 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@^2.2.0",
+          "from": "debug@*",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "from": "ms@0.7.1"
             }
           }
         },
@@ -247,8 +396,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
                   "version": "1.0.1",
@@ -262,86 +410,17 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
       }
     },
-    "nock": {
-      "version": "7.2.2",
-      "from": "nock@~7.2.2",
-      "dependencies": {
-        "chai": {
-          "version": "3.5.0",
-          "from": "chai@>=1.9.2 <4.0.0",
-          "dependencies": {
-            "assertion-error": {
-              "version": "1.0.1",
-              "from": "assertion-error@^1.0.1"
-            },
-            "deep-eql": {
-              "version": "0.1.3",
-              "from": "deep-eql@^0.1.3",
-              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-              "dependencies": {
-                "type-detect": {
-                  "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
-                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-                }
-              }
-            },
-            "type-detect": {
-              "version": "1.0.0",
-              "from": "type-detect@^1.0.0"
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@^2.2.0",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "from": "deep-equal@^1.0.0"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@^5.0.1"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@^0.5.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "propagate": {
-          "version": "0.3.1",
-          "from": "propagate@0.3.x"
-        },
-        "qs": {
-          "version": "6.1.0",
-          "from": "qs@^6.0.2"
-        }
-      }
-    },
     "grunt": {
       "version": "0.4.5",
       "from": "grunt@~0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
@@ -355,7 +434,8 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2"
+          "from": "colors@~0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
@@ -364,7 +444,8 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13"
+          "from": "eventemitter2@~0.4.13",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
@@ -384,6 +465,7 @@
                 "minimatch": {
                   "version": "0.3.0",
                   "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -392,7 +474,8 @@
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -400,7 +483,8 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
@@ -443,7 +527,8 @@
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0"
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
@@ -454,7 +539,8 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@1"
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
@@ -495,13 +581,15 @@
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0"
+                  "from": "underscore.string@~2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2"
+              "from": "esprima@~ 1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
@@ -523,6 +611,7 @@
         "grunt-legacy-log": {
           "version": "0.1.3",
           "from": "grunt-legacy-log@~0.1.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
@@ -536,7 +625,8 @@
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3"
+              "from": "underscore.string@~2.3.3",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
         }
@@ -545,14 +635,17 @@
     "grunt-contrib-watch": {
       "version": "0.5.3",
       "from": "grunt-contrib-watch@~0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.5.3.tgz",
       "dependencies": {
         "gaze": {
           "version": "0.4.3",
           "from": "gaze@~0.4.0",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.4.3.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
               "from": "globule@~0.1.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
@@ -579,6 +672,7 @@
                 "minimatch": {
                   "version": "0.2.14",
                   "from": "minimatch@~0.2.11",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -587,7 +681,8 @@
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -602,23 +697,28 @@
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "qs@~0.5.2"
+              "from": "qs@~0.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3"
+              "from": "faye-websocket@~0.4.3",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
               "from": "noptify@latest",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
                   "from": "nopt@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1"
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 }
@@ -626,7 +726,8 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@~0.7.0"
+              "from": "debug@~0.7.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         }
@@ -635,10 +736,12 @@
     "grunt-mocha-test": {
       "version": "0.7.0",
       "from": "grunt-mocha-test@~0.7.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.7.0.tgz",
       "dependencies": {
         "mocha": {
           "version": "1.13.0",
           "from": "mocha@~1.13.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.13.0.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
@@ -647,7 +750,8 @@
             },
             "growl": {
               "version": "1.7.0",
-              "from": "growl@1.7.x"
+              "from": "growl@1.7.x",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
             },
             "jade": {
               "version": "0.26.3",
@@ -668,7 +772,8 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@^2.2.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
@@ -690,6 +795,7 @@
                 "minimatch": {
                   "version": "0.2.14",
                   "from": "minimatch@~0.2.11",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -698,17 +804,19 @@
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0"
+                  "from": "graceful-fs@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -720,22 +828,27 @@
     "grunt-jsbeautifier": {
       "version": "0.2.10",
       "from": "grunt-jsbeautifier@~0.2.6",
+      "resolved": "https://registry.npmjs.org/grunt-jsbeautifier/-/grunt-jsbeautifier-0.2.10.tgz",
       "dependencies": {
         "grunt": {
           "version": "0.4.5",
           "from": "grunt@>=0.4.1",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "async@~0.1.22"
+              "from": "async@~0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "coffee-script": {
               "version": "1.3.3",
-              "from": "coffee-script@~1.3.3"
+              "from": "coffee-script@~1.3.3",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@~0.6.2"
+              "from": "colors@~0.6.2",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "dateformat": {
               "version": "1.0.2-1.2.3",
@@ -744,11 +857,13 @@
             },
             "eventemitter2": {
               "version": "0.4.14",
-              "from": "eventemitter2@~0.4.13"
+              "from": "eventemitter2@~0.4.13",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
             },
             "findup-sync": {
               "version": "0.1.3",
               "from": "findup-sync@~0.1.2",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
@@ -757,12 +872,13 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
                       "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.3",
@@ -771,7 +887,8 @@
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@~1.0.0"
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     }
@@ -779,17 +896,20 @@
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@~2.4.1"
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.1.21",
               "from": "glob@~3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0"
+                  "from": "graceful-fs@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.2",
@@ -805,11 +925,13 @@
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11"
+              "from": "iconv-lite@~0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
               "from": "minimatch@~0.2.12",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
@@ -818,17 +940,20 @@
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "nopt": {
               "version": "1.0.10",
               "from": "nopt@~1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@1"
+                  "from": "abbrev@1",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
@@ -839,23 +964,28 @@
             },
             "lodash": {
               "version": "0.9.2",
-              "from": "lodash@~0.9.2"
+              "from": "lodash@~0.9.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
             },
             "underscore.string": {
               "version": "2.2.1",
-              "from": "underscore.string@~2.2.1"
+              "from": "underscore.string@~2.2.1",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@~1.0.5"
+              "from": "which@~1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "js-yaml": {
               "version": "2.0.5",
               "from": "js-yaml@~2.0.5",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
                   "from": "argparse@~ 0.1.11",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.7.0",
@@ -864,43 +994,52 @@
                     },
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0"
+                      "from": "underscore.string@~2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2"
+                  "from": "esprima@~ 1.0.2",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.1"
+              "from": "exit@~0.1.1",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "getobject": {
               "version": "0.1.0",
-              "from": "getobject@~0.1.0"
+              "from": "getobject@~0.1.0",
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
             },
             "grunt-legacy-util": {
               "version": "0.2.0",
-              "from": "grunt-legacy-util@~0.2.0"
+              "from": "grunt-legacy-util@~0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
             },
             "grunt-legacy-log": {
               "version": "0.1.3",
               "from": "grunt-legacy-log@~0.1.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
               "dependencies": {
                 "grunt-legacy-log-utils": {
                   "version": "0.1.1",
-                  "from": "grunt-legacy-log-utils@~0.1.1"
+                  "from": "grunt-legacy-log-utils@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@~2.4.1"
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.3"
+                  "from": "underscore.string@~2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
             }
@@ -909,14 +1048,17 @@
         "js-beautify": {
           "version": "1.6.2",
           "from": "js-beautify@>=1.4.2",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.10",
               "from": "config-chain@~1.1.5",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@~1.2.1"
+                  "from": "proto-list@~1.2.1",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
@@ -928,6 +1070,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "from": "mkdirp@~0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -939,10 +1082,12 @@
             "nopt": {
               "version": "3.0.6",
               "from": "nopt@~3.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@1"
+                  "from": "abbrev@1",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             }
@@ -951,10 +1096,12 @@
         "rc": {
           "version": "1.1.6",
           "from": "rc@>=0.5.5",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "dependencies": {
             "deep-extend": {
               "version": "0.4.1",
-              "from": "deep-extend@~0.4.0"
+              "from": "deep-extend@~0.4.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
@@ -963,7 +1110,8 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@^1.2.0"
+              "from": "minimist@^1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
@@ -974,64 +1122,89 @@
         },
         "semver": {
           "version": "5.1.0",
-          "from": "semver@>=4.3.1"
+          "from": "semver@>=4.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
         },
         "underscore.string": {
-          "version": "3.2.3",
-          "from": "underscore.string@>=2.3.3"
+          "version": "3.3.4",
+          "from": "underscore.string@>=2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.0.3",
+              "from": "sprintf-js@^1.0.3",
+              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@^1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.6.5",
       "from": "grunt-contrib-jshint@~0.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.6.5.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.1.11",
           "from": "jshint@~2.1.10",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.1.11.tgz",
           "dependencies": {
             "shelljs": {
               "version": "0.1.4",
-              "from": "shelljs@0.1.x"
+              "from": "shelljs@0.1.x",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "cli": {
               "version": "0.4.5",
               "from": "cli@0.4.x",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "7.0.0",
+                  "version": "7.0.3",
                   "from": "glob@>= 3.1.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
                       "from": "inflight@^1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1"
+                          "from": "wrappy@1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
                       "from": "minimatch@2 || 3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
                           "from": "brace-expansion@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@^0.3.0"
+                              "from": "balanced-match@^0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
@@ -1045,10 +1218,12 @@
                     "once": {
                       "version": "1.3.3",
                       "from": "once@^1.3.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1"
+                          "from": "wrappy@1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
@@ -1068,17 +1243,20 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "console-browserify": {
               "version": "0.1.6",
-              "from": "console-browserify@0.1.x"
+              "from": "console-browserify@0.1.x",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -27,18 +27,20 @@
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-watch": "~0.5.0",
     "grunt-mocha-test": "~0.7.0",
-    "should": "~2.1.0",
-    "mocha": "~1.14.0",
+    "mocha": "~1.18.0",
     "grunt-jsbeautifier": "~0.2.6",
-    "sinon": "1.9.1",
-    "nock": "~7.2.2"
+    "sinon": "1.12.1",
+    "nock": "~7.2.2",
+    "leche": "~2.1.1"
   },
   "dependencies": {
     "async": "~0.2.9",
+    "cache-service": "~1.3.5",
+    "cache-service-node-cache": "^1.1.1",
+    "cache-service-redis": "^1.1.3",
     "crypto-js": "3.1.2-2",
-    "lodash": "3.10.1",
-    "redis": "~0.9.1",
     "jsonwebtoken": "~5.7.0",
+    "lodash": "3.10.1",
     "should": "~3.3.2"
   }
 }

--- a/test/authorization_tests.js
+++ b/test/authorization_tests.js
@@ -7,276 +7,308 @@ var persona = require("../index");
 var _getOAuthToken = require("./utils")._getOAuthToken;
 var runBeforeEach = require("./utils").beforeEach;
 var runAfterEach = require("./utils").afterEach;
+var leche = require("leche");
+var withData = leche.withData;
 
 describe("Persona Client Test Suite - Authorization Tests", function() {
 
     var personaClient;
+    var oauthClient = process.env.PERSONA_TEST_OAUTH_CLIENT || "primate";
+    var oauthSecret = process.env.PERSONA_TEST_OAUTH_SECRET || "bananas";
 
-    beforeEach(function createClientAndStubs() {
-        runBeforeEach(this.currentTest.parent.title + " " + this.currentTest.title, "authorization", true);
-
-        personaClient = persona.createClient({
-            persona_host:"persona",
-            persona_port:80,
-            persona_scheme:"http",
-            persona_oauth_route:"/oauth/tokens/",
-            redis_host:"localhost",
-            redis_port:6379,
-            redis_db:0,
+    withData({
+        "default-cache": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
             enable_debug: false
+        },
+        "redis": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            cache: {
+                module: "redis",
+                options: {
+                    redisData: {
+                        hostname: "localhost",
+                        port: 6379
+                    }
+                }
+            },
+            enable_debug: false
+        },
+        "legacy-config-options": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            redis_host: "localhost",
+            redis_port: 6379,
+            redis_db: 0,
+            enable_debug: false
+        }
+    }, function(personaClientConfig) {
+        beforeEach(function createClientAndStubs() {
+            runBeforeEach(this.currentTest.parent.title + " " + this.currentTest.title, "authorization", true);
+
+            personaClient = persona.createClient(personaClientConfig);
+            sinon.stub(personaClient.tokenCache, "get").yields(null, null);
         });
-        sinon.stub(personaClient.redisClient, "get").yields(null, null);
-    });
 
-    afterEach(function restoreStubs() {
-        runAfterEach(this.currentTest.parent.title + " " + this.currentTest.title, "authorization", true);
-        personaClient.redisClient.get.restore();
-    });
+        afterEach(function restoreStubs() {
+            runAfterEach(this.currentTest.parent.title + " " + this.currentTest.title, "authorization", true);
+            personaClient.tokenCache.get.restore();
+        });
 
-    describe("Request authorization tests",function() {
+        describe("Request authorization tests",function() {
 
-        it("should throw an error if guid is not present", function(done) {
-            personaClient.requestAuthorization(null,"test title","some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if guid is not present", function(done) {
+                personaClient.requestAuthorization(null,"test title","some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if guid is not a string", function(done) {
-            personaClient.requestAuthorization({},"test title","some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if guid is not a string", function(done) {
+                personaClient.requestAuthorization({},"test title","some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if title is not present", function(done) {
-            personaClient.requestAuthorization("guid",null,"some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if title is not present", function(done) {
+                personaClient.requestAuthorization("guid",null,"some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if title is not a string", function(done) {
-            personaClient.requestAuthorization("guid",{},"some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if title is not a string", function(done) {
+                personaClient.requestAuthorization("guid",{},"some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client id is not present", function(done) {
-            personaClient.requestAuthorization("guid","test title",null,"some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client id is not present", function(done) {
+                personaClient.requestAuthorization("guid","test title",null,"some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client id is not a string", function(done) {
-            personaClient.requestAuthorization("guid","test title",{},"some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client id is not a string", function(done) {
+                personaClient.requestAuthorization("guid","test title",{},"some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client secret is not present", function(done) {
-            personaClient.requestAuthorization("guid","test title","some_id",null,function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client secret is not present", function(done) {
+                personaClient.requestAuthorization("guid","test title","some_id",null,function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client secret is not a string", function(done) {
-            personaClient.requestAuthorization("guid","test title","some_id",{},function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, title, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client secret is not a string", function(done) {
+                personaClient.requestAuthorization("guid","test title","some_id",{},function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, title, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should return 400 if id and secret not valid", function(done) {
-            personaClient.requestAuthorization("guid","test title","some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("Request authorization failed with error: Generate token failed with status code 400");
-                assert(data===null);
-                done();
+            it("should return 400 if id and secret not valid", function(done) {
+                personaClient.requestAuthorization("guid","test title","some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("Request authorization failed with error: Generate token failed with status code 400");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        xit("should return 401 if token scope not valid", function(done) {
-            // todo: how do I get a token without su scope? bah! Also fix persona before enabling this test
-            _getOAuthToken("invalid_scope",function(err,token) {
-                personaClient.requestAuthorization("guid_does_not_exist","test title","some_id","some_secret",function(err,data) {
+            xit("should return 401 if token scope not valid", function(done) {
+                // todo: how do I get a token without su scope? bah! Also fix persona before enabling this test
+                _getOAuthToken("invalid_scope",function(err,token) {
+                    personaClient.requestAuthorization("guid_does_not_exist","test title","some_id","some_secret",function(err,data) {
+                        assert(err!=null);
+                        err.should.be.a.String;
+                        err.should.equal("Request authorization failed with status code 404");
+                        assert(data===null);
+                        done();
+                    });
+                })
+            });
+
+            it("should return 404 if user does not exist", function(done) {
+                personaClient.requestAuthorization("guid_does_not_exist", "test title", oauthClient, oauthSecret, function(err, data) {
                     assert(err!=null);
                     err.should.be.a.String;
                     err.should.equal("Request authorization failed with status code 404");
                     assert(data===null);
                     done();
                 });
-            })
-        });
-
-        it("should return 404 if user does not exist", function(done) {
-            personaClient.requestAuthorization("guid_does_not_exist","test title","primate","bananas",function(err,data) { // todo: move these creds somewhere else
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("Request authorization failed with status code 404");
-                assert(data===null);
-                done();
             });
-        });
 
-        xit("should return credentials", function(done) {
-            // todo: how to get a valid guid?
-            personaClient.requestAuthorization("guid_does_exist","test title","some_id","some_secret",function(err,data) {
-                assert(err===null);
-                assert(data!==null);
-                data.should.be.an.Object;
-                done();
+            xit("should return credentials", function(done) {
+                // todo: how to get a valid guid?
+                personaClient.requestAuthorization("guid_does_exist","test title","some_id","some_secret",function(err,data) {
+                    if (err) {
+                      done(err);
+                    }
+                    assert(data!==null);
+                    data.should.be.an.Object;
+                    done();
+                });
             });
+
         });
 
-    });
-
-    describe("Delete authorization tests",function(){
-        it("should throw an error if guid is not present", function(done) {
-            personaClient.deleteAuthorization(null,"some_client_id","some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+        describe("Delete authorization tests",function(){
+            it("should throw an error if guid is not present", function(done) {
+                personaClient.deleteAuthorization(null,"some_client_id","some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if guid is not a string", function(done) {
-            personaClient.deleteAuthorization({},"some_client_id","some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if guid is not a string", function(done) {
+                personaClient.deleteAuthorization({},"some_client_id","some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if authorization_client_id is not present", function(done) {
-            personaClient.deleteAuthorization("guid", null,"some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if authorization_client_id is not present", function(done) {
+                personaClient.deleteAuthorization("guid", null,"some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if authorization_client_id is not a string", function(done) {
-            personaClient.deleteAuthorization("guid", {},"some_id","some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if authorization_client_id is not a string", function(done) {
+                personaClient.deleteAuthorization("guid", {},"some_id","some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client id is not present", function(done) {
-            personaClient.deleteAuthorization("guid", "authorization_client_id",null,"some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client id is not present", function(done) {
+                personaClient.deleteAuthorization("guid", "authorization_client_id",null,"some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client id is not a string", function(done) {
-            personaClient.deleteAuthorization("guid", "authorization_client_id",{},"some_secret",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client id is not a string", function(done) {
+                personaClient.deleteAuthorization("guid", "authorization_client_id",{},"some_secret",function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client secret is not present", function(done) {
-            personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", null,function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client secret is not present", function(done) {
+                personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", null,function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should throw an error if client secret is not a string", function(done) {
-            personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", null,function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("guid, authorization_client_id, id and secret are required strings");
-                assert(data===null);
-                done();
+            it("should throw an error if client secret is not a string", function(done) {
+                personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", null,function(err,data) {
+                    assert(err!=null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, authorization_client_id, id and secret are required strings");
+                    assert(data===null);
+                    done();
+                });
             });
-        });
 
-        it("should return 400 if id and secret not valid", function(done) {
-            personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", "some_secret",function(err) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("Request authorization failed with error: Generate token failed with status code 400");
-                done();
-            });
-        });
-
-        xit("should return 401 if token scope not valid", function(done) {
-            // todo: how do I get a token without su scope? bah! Also fix persona first before enabling this test
-            _getOAuthToken("invalid_scope",function(err,token) {
+            it("should return 400 if id and secret not valid", function(done) {
                 personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", "some_secret",function(err) {
                     assert(err!=null);
                     err.should.be.a.String;
-                    err.should.equal("Request authorization failed with status code 404");
+                    err.should.equal("Request authorization failed with error: Generate token failed with status code 400");
                     done();
                 });
-            })
-        });
+            });
 
-        it("should return 204 if user does not exist", function(done) {
-            personaClient.deleteAuthorization("guid_does_not_exist", "authorization_client_id","primate", "bananas",function(err) { //todo: move those credentials
-                assert(err==null);
-                done();
+            xit("should return 401 if token scope not valid", function(done) {
+                // todo: how do I get a token without su scope? bah! Also fix persona first before enabling this test
+                _getOAuthToken("invalid_scope",function(err,token) {
+                    personaClient.deleteAuthorization("guid", "authorization_client_id","some_id", "some_secret",function(err) {
+                        assert(err!=null);
+                        err.should.be.a.String;
+                        err.should.equal("Request authorization failed with status code 404");
+                        done();
+                    });
+                })
+            });
+
+            it("should return 204 if user does not exist", function(done) {
+                personaClient.deleteAuthorization("guid_does_not_exist", "authorization_client_id", oauthClient, oauthSecret, function(err) {
+                    assert(err==null);
+                    done();
+                });
+            });
+
+            it("should return 204 if user does exist", function(done) {
+                // todo: how do a get a valid guid?
+                personaClient.deleteAuthorization("guid", "authorization_client_id", oauthClient, oauthSecret, function(err) {
+                    assert(err==null);
+                    done();
+                });
             });
         });
+    });
 
-        it("should return 204 if user does exist", function(done) {
-            // todo: how do a get a valid guid?
-            personaClient.deleteAuthorization("guid", "authorization_client_id","primate", "bananas",function(err) { //todo: move those credentials
-                console.log(err);
-                assert(err==null);
-                done();
-            });
-        });
-
-    })
 });

--- a/test/persona_client_tests.js
+++ b/test/persona_client_tests.js
@@ -6,6 +6,8 @@ var persona = require("../index");
 var sinon = require("sinon");
 var runBeforeEach = require("./utils").beforeEach;
 var runAfterEach = require("./utils").afterEach;
+var leche = require("leche");
+var withData = leche.withData;
 
 describe("Persona Client Test Suite - Constructor & Token Tests", function() {
 
@@ -19,90 +21,58 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
 
     describe("- Constructor tests", function() {
 
-        it("should throw error if config.persona_host is not supplied", function(done){
-            var personaClient = function(){
+        it("should throw error if config.persona_host is not supplied", function(done) {
+            var personaClient = function() {
                 return persona.createClient({});
             };
             personaClient.should.throw("You must specify the persona host");
             done();
         });
-        it("should throw error if config.persona_port is not supplied", function(done){
-            var personaClient = function(){
-                return persona.createClient({persona_host:"persona"});
+        it("should throw error if config.persona_port is not supplied", function(done) {
+            var personaClient = function() {
+                return persona.createClient({persona_host: "persona"});
             };
             personaClient.should.throw("You must specify the persona port");
             done();
         });
-        it("should throw error if config.persona_scheme is not supplied", function(done){
+        it("should throw error if config.persona_scheme is not supplied", function(done) {
             var personaClient = function(){
                 return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80
+                    persona_host: "persona",
+                    persona_port: 80
                 });
             };
             personaClient.should.throw("You must specify the persona scheme");
             done();
         });
-        it("should throw error if config.persona_oauth_route is not supplied", function(done){
-            var personaClient = function(){
+        it("should throw error if config.persona_oauth_route is not supplied", function(done) {
+            var personaClient = function() {
                 return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80,
-                    persona_scheme:"http"
+                    persona_host: "persona",
+                    persona_port: 80,
+                    persona_scheme: "http"
                 });
             };
             personaClient.should.throw("You must specify the persona oauth route");
             done();
         });
-        it("should throw error if config.redis_host is not supplied", function(done){
-            var personaClient = function(){
+
+        it("should NOT throw any error if all config params are defined", function(done) {
+            var personaClient = function() {
                 return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80,
-                    persona_scheme:"http",
-                    persona_oauth_route:"/oauth/tokens"
-                });
-            };
-            personaClient.should.throw("You must specify the redis host");
-            done();
-        });
-        it("should throw error if config.redis_port is not supplied", function(done){
-            var personaClient = function(){
-                return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80,
-                    persona_scheme:"http",
-                    persona_oauth_route:"/oauth/tokens",
-                    redis_host:"localhost"
-                });
-            };
-            personaClient.should.throw("You must specify the redis port");
-            done();
-        });
-        it("should throw error if config.redis_db is not supplied", function(done){
-            var personaClient = function(){
-                return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80,
-                    persona_scheme:"http",
-                    persona_oauth_route:"/oauth/tokens",
-                    redis_host:"localhost",
-                    redis_port:6379
-                });
-            };
-            personaClient.should.throw("You must specify the redis db");
-            done();
-        });
-        it("should NOT throw any error if all config params are defined", function(done){
-            var personaClient = function(){
-                return persona.createClient({
-                    persona_host:"persona",
-                    persona_port:80,
-                    persona_scheme:"http",
-                    persona_oauth_route:"/oauth/tokens",
-                    redis_host:"localhost",
-                    redis_port:6379,
-                    redis_db:0
+                    persona_host: "persona",
+                    persona_port: 80,
+                    persona_scheme: "http",
+                    persona_oauth_route: "/oauth/tokens",
+                    cache: {
+                        module: "redis",
+                        options: {
+                            redisData: {
+                                hostname: "localhost",
+                                port: 6379
+                            }
+                        }
+                    }
                 });
             };
             personaClient.should.not.throw();
@@ -112,109 +82,113 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
 
     describe("- Generate token tests", function() {
         var clock;
-        beforeEach(function () {
-            clock = sinon.useFakeTimers();
-        });
+        var oauthClient = process.env.PERSONA_TEST_OAUTH_CLIENT || "primate";
+        var oauthSecret = process.env.PERSONA_TEST_OAUTH_SECRET || "bananas";
 
-        afterEach(function () {
-            clock.restore();
-        });
-
-        it("should throw error if there is no id",function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
+        withData({
+            "default-cache": {
+                persona_host: process.env.PERSONA_TEST_HOST || "persona",
+                persona_port: process.env.PERSONA_TEST_PORT || 80,
+                persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+                persona_oauth_route: "/oauth/tokens/",
                 enable_debug: false
+            },
+            "redis": {
+                persona_host: process.env.PERSONA_TEST_HOST || "persona",
+                persona_port: process.env.PERSONA_TEST_PORT || 80,
+                persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+                persona_oauth_route: "/oauth/tokens/",
+                cache: {
+                    module: "redis",
+                    options: {
+                        redisData: {
+                            hostname: "localhost",
+                            port: 6379
+                        }
+                    }
+                },
+                enable_debug: false
+            },
+            "legacy-config-options": {
+                persona_host: process.env.PERSONA_TEST_HOST || "persona",
+                persona_port: process.env.PERSONA_TEST_PORT || 80,
+                persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+                persona_oauth_route: "/oauth/tokens/",
+                redis_host: "localhost",
+                redis_port: 6379,
+                redis_db: 0,
+                enable_debug: false
+            }
+        }, function(personaClientConfig) {
+            beforeEach(function () {
+                clock = sinon.useFakeTimers();
             });
 
-            var validateUrl = function(){
-                return personaClient.obtainToken(null,"bananas",function(err,data) {});
-            };
-
-            validateUrl.should.throw("You must provide an ID to obtain a token");
-            done();
-        });
-        it("should throw error if there is no secret",function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+            afterEach(function () {
+                clock.restore();
             });
 
-            var validateUrl = function(){
-                return personaClient.obtainToken("primate",null,function(err,data) {});
-            };
+            it("should throw error if there is no id", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            validateUrl.should.throw("You must provide a secret to obtain a token");
-            done();
-        });
-        it("should return a token, and cache that token",function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                var validateUrl = function() {
+                    return personaClient.obtainToken(null, "bananas", function(err, data) {});
+                };
+
+                validateUrl.should.throw("You must provide an ID to obtain a token");
+                done();
             });
+            it("should throw error if there is no secret", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            personaClient._removeTokenFromCache("primate","bananas",function(err) {
-                assert(err===null);
-                personaClient.obtainToken("primate","bananas",function(err,data1) {
-                    assert(err===null);
-                    data1.should.have.property("access_token");
-                    data1.should.have.property("expires_in");
-                    data1.expires_in.should.equal(3600);
-                    data1.should.have.property("scope");
-                    data1.should.have.property("token_type");
-                    clock.tick(1000); //move clock forward by 1s to make sure expires_in is different
+                var validateUrl = function(){
+                    return personaClient.obtainToken(oauthClient, null, function(err, data) {});
+                };
 
-                    personaClient.obtainToken("primate","bananas",function(err,data2) {
+                validateUrl.should.throw("You must provide a secret to obtain a token");
+                done();
+            });
+            it("should return a token, and cache that token", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient._removeTokenFromCache(oauthClient, oauthSecret, function(err) {
+                    assert(err === null);
+                    personaClient.obtainToken(oauthClient, oauthSecret, function(err, data1) {
                         assert(err===null);
-                        data2.should.have.property("access_token");
-                        data2.should.have.property("expires_in");
-                        data2.should.have.property("scope");
-                        data2.should.have.property("token_type");
+                        data1.should.have.property("access_token");
+                        data1.should.have.property("expires_in");
+                        data1.expires_in.should.equal(3600);
+                        data1.should.have.property("scope");
+                        data1.should.have.property("token_type");
+                        clock.tick(1000); //move clock forward by 1s to make sure expires_in is different
 
-                        data1.access_token.should.equal(data2.access_token);
-                        data1.expires_in.should.not.equal(data2.expires_in);
+                        personaClient.obtainToken(oauthClient, oauthSecret, function(err, data2) {
+                            assert(err===null);
+                            data2.should.have.property("access_token");
+                            data2.should.have.property("expires_in");
+                            data2.should.have.property("scope");
+                            data2.should.have.property("token_type");
 
-                        done();
+                            data1.access_token.should.equal(data2.access_token);
+                            data1.expires_in.should.not.equal(data2.expires_in);
+
+                            done();
+                        });
                     });
                 });
             });
-        });
-        it("should not return a token",function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
+            it("should not return a token",function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            personaClient.obtainToken("primate","wrong_password",function(err,data) {
-                assert(err!=null);
-                err.should.be.a.String;
-                err.should.equal("Generate token failed with status code 400");
-                assert(data===null);
-                done();
+                personaClient.obtainToken("primate","wrong_password",function(err, data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("Generate token failed with status code 400");
+                    assert(data===null);
+                    done();
+                });
             });
         });
     });
+
 });

--- a/test/presigned_url_tests.js
+++ b/test/presigned_url_tests.js
@@ -6,416 +6,320 @@ var persona = require("../index");
 var cryptojs = require("crypto-js");
 var runBeforeEach = require("./utils").beforeEach;
 var runAfterEach = require("./utils").afterEach;
+var leche = require("leche");
+var withData = leche.withData;
 
 describe("Persona Client Test Suite - Presigned URL Tests", function() {
 
-    beforeEach(function() {
-        runBeforeEach(this.currentTest.title, "presigned_url");
+    withData({
+        "default-cache": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            enable_debug: false
+        },
+        "redis": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            cache: {
+                module: "redis",
+                options: {
+                    redisData: {
+                        hostname: "localhost",
+                        port: 6379
+                    }
+                }
+            },
+            enable_debug: false
+        },
+        "legacy-config-options": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            redis_host: "localhost",
+            redis_port: 6379,
+            redis_db: 0,
+            enable_debug: false
+        }
+    }, function(personaClientConfig) {
+        beforeEach(function() {
+            runBeforeEach(this.currentTest.title, "presigned_url");
+        });
+
+        afterEach(function() {
+            runAfterEach(this.currentTest.title, "presigned_url");
+        });
+
+        describe("- Generate and Validate Presigned Url Tests", function() {
+
+            var secret = "canyoukeepasecret";
+
+            it("should throw error if no URL is provided to sign", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var presignUrl = function(){
+                    return personaClient.presignUrl(null, secret, null, function(err, result){});
+                };
+
+                presignUrl.should.throw("You must provide a URL to sign");
+                done();
+
+            });
+
+            it("should throw error if no secret is provided to sign with", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633';
+
+                var presignUrl = function(){
+                    return personaClient.presignUrl(urlToSign, null, null, function(err, result){});
+                };
+
+                presignUrl.should.throw("You must provide a secret with which to sign the url");
+                done();
+
+            });
+
+            it("should generate presigned URL", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633';
+                var expectedHash = cryptojs.HmacSHA256(urlToSign, secret);
+
+                personaClient.presignUrl(urlToSign, secret, null, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.equal('http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633&signature='+expectedHash);
+                    done();
+                });
+
+            });
+
+            it("should generate presigned URL and add default expiry", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google';
+
+                personaClient.presignUrl(urlToSign, secret, null, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.containEql('&expires=');
+                    done();
+                });
+
+            });
+
+            it("should generate presigned URL and add passed expiry", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google';
+
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var expiry = new Date().getTime() + 86400;
+
+                var urlWithExp = baseUrl + '&expires=' + expiry;
+
+                var expectedHash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var expectedURL = baseUrl + '&expires=' + expiry + '&signature=' + expectedHash;
+
+                personaClient.presignUrl(urlToSign, secret, expiry, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.equal(expectedURL);
+                    done();
+                });
+
+            });
+
+            it("should generate presigned URL that has hash component", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var expectedHash = cryptojs.HmacSHA256(urlToSign, secret);
+                var expectedUrl = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633&signature=' + expectedHash + '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+
+                personaClient.presignUrl(urlToSign, secret, null, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.equal(expectedUrl);
+
+                    done();
+                });
+
+            });
+
+            it("should generate presigned URL that has hash component and add default expiry", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google' + urlHash;
+
+                personaClient.presignUrl(urlToSign, secret, null, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.containEql('&expires=');
+                    result.should.containEql(urlHash);
+
+                    done();
+                });
+
+            });
+
+            it("should generate presigned URL that has hash component and add passed expiry", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var urlToSign = baseUrl + urlHash;
+                var expiry = new Date().getTime() + 86400;
+
+                var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
+
+                var expectedHash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var expectedURL = baseUrl + '&expires=' + expiry + '&signature=' + expectedHash + urlHash;
+
+                personaClient.presignUrl(urlToSign, secret, expiry, function(err, result){
+                    if(err) return done(err);
+
+                    result.should.equal(expectedURL);
+
+                    done();
+                });
+
+            });
+
+            it("should throw error if no presigned URL is provided to validate", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var validateUrl = function(){
+                    return personaClient.isPresignedUrlValid(null, secret);
+                };
+
+                validateUrl.should.throw("You must provide a URL to validate");
+                done();
+
+            });
+
+            it("should throw error if no secret is provided to validate", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlToValidate = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395229157990&signature=ae1ef4f1f2e8a45643e51ab34cc1d08dd627f5bb6e9569b84bcce622040a41fb#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+
+                var validateUrl = function(){
+                    return personaClient.isPresignedUrlValid(urlToValidate, null);
+                };
+
+                validateUrl.should.throw("You must provide a secret with which to validate the url");
+                done();
+
+            });
+
+            it("should validate a presigned URL with no querystring or hash parameters", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var baseUrl = 'http://192.168.10.62:3000/player';
+                var expiry = new Date().getTime() + 86400;
+
+                var urlWithExp = baseUrl + '?expires=' + expiry;
+
+                var hash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var urlToValidate = baseUrl + '?expires=' + expiry + '&signature=' + hash;
+
+                var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
+
+                result.should.equal(true);
+
+                done();
+            });
+
+            it("should validate a presigned URL", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var urlToSign = baseUrl + urlHash;
+                var expiry = new Date().getTime() + 86400;
+
+                var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
+
+                var hash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var urlToValidate = baseUrl + '&expires=' + expiry + '&signature=' + hash + urlHash;
+
+                var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
+
+                result.should.equal(true);
+
+                done();
+            });
+
+            it("should validate a presigned URL has an expiry", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var urlToSign = baseUrl + urlHash;
+                var hash = cryptojs.HmacSHA256(urlToSign, secret);
+
+                var urlToValidate = baseUrl + '&signature=' + hash + urlHash;
+
+                var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
+
+                result.should.equal(false);
+
+                done();
+            });
+
+            it("should validate a presigned URL has expired", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var urlToSign = baseUrl + urlHash;
+                var expiry = Math.floor(new Date().getTime()/1000) - 5;
+
+                var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
+
+                var hash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var urlToValidate = baseUrl + '&expires=' + expiry + '&signature=' + hash + urlHash;
+
+                var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
+
+                result.should.equal(false);
+
+                done();
+            });
+
+            it("should validate a presigned URL is invalid", function(done){
+                var personaClient = persona.createClient(personaClientConfig);
+
+                var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
+                var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
+                var urlToSign = baseUrl + urlHash;
+                var expiry = new Date().getTime() + 86400;
+
+                var urlWithExp = baseUrl + '&expiry=' + expiry + urlHash + '23'; // add additional data that will cause an invalid hash to be generated
+
+                var hash = cryptojs.HmacSHA256(urlWithExp, secret);
+
+                var urlToValidate = baseUrl + '&expiry=' + expiry + '&signature=' + hash + urlHash;
+
+                var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
+
+                result.should.equal(false);
+
+                done();
+            });
+
+        });
     });
 
-    afterEach(function() {
-        runAfterEach(this.currentTest.title, "presigned_url");
-    });
-
-    describe("- Generate and Validate Presigned Url Tests", function() {
-
-        var secret = "canyoukeepasecret";
-
-        it("should throw error if no URL is provided to sign", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var presignUrl = function(){
-                return personaClient.presignUrl(null, secret, null, function(err, result){});
-            };
-
-            presignUrl.should.throw("You must provide a URL to sign");
-            done();
-
-        });
-
-        it("should throw error if no secret is provided to sign with", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633';
-
-            var presignUrl = function(){
-                return personaClient.presignUrl(urlToSign, null, null, function(err, result){});
-            };
-
-            presignUrl.should.throw("You must provide a secret with which to sign the url");
-            done();
-
-        });
-
-        it("should generate presigned URL", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633';
-            var expectedHash = cryptojs.HmacSHA256(urlToSign, secret);
-
-            personaClient.presignUrl(urlToSign, secret, null, function(err, result){
-                if(err) return done(err);
-
-                result.should.equal('http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633&signature='+expectedHash);
-                done();
-            });
-
-        });
-
-        it("should generate presigned URL and add default expiry", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google';
-
-            personaClient.presignUrl(urlToSign, secret, null, function(err, result){
-                if(err) return done(err);
-
-                result.should.containEql('&expires=');
-                done();
-            });
-
-        });
-
-        it("should generate presigned URL and add passed expiry", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google';
-
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var expiry = new Date().getTime() + 86400;
-
-            var urlWithExp = baseUrl + '&expires=' + expiry;
-
-            var expectedHash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var expectedURL = baseUrl + '&expires=' + expiry + '&signature=' + expectedHash;
-
-            personaClient.presignUrl(urlToSign, secret, expiry, function(err, result){
-                if(err) return done(err);
-
-                result.should.equal(expectedURL);
-                done();
-            });
-
-        });
-
-        it("should generate presigned URL that has hash component", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var expectedHash = cryptojs.HmacSHA256(urlToSign, secret);
-            var expectedUrl = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395160411633&signature=' + expectedHash + '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-
-            personaClient.presignUrl(urlToSign, secret, null, function(err, result){
-                if(err) return done(err);
-
-                result.should.equal(expectedUrl);
-
-                done();
-            });
-
-        });
-
-        it("should generate presigned URL that has hash component and add default expiry", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var urlToSign = 'http://192.168.10.62:3000/player?shortcode=google' + urlHash;
-
-            personaClient.presignUrl(urlToSign, secret, null, function(err, result){
-                if(err) return done(err);
-
-                result.should.containEql('&expires=');
-                result.should.containEql(urlHash);
-
-                done();
-            });
-
-        });
-
-        it("should generate presigned URL that has hash component and add passed expiry", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var urlToSign = baseUrl + urlHash;
-            var expiry = new Date().getTime() + 86400;
-
-            var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
-
-            var expectedHash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var expectedURL = baseUrl + '&expires=' + expiry + '&signature=' + expectedHash + urlHash;
-
-            personaClient.presignUrl(urlToSign, secret, expiry, function(err, result){
-                if(err) return done(err);
-
-                result.should.equal(expectedURL);
-
-                done();
-            });
-
-        });
-
-        it("should throw error if no presigned URL is provided to validate", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var validateUrl = function(){
-                return personaClient.isPresignedUrlValid(null, secret);
-            };
-
-            validateUrl.should.throw("You must provide a URL to validate");
-            done();
-
-        });
-
-        it("should throw error if no secret is provided to validate", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlToValidate = 'http://192.168.10.62:3000/player?shortcode=google&expires=1395229157990&signature=ae1ef4f1f2e8a45643e51ab34cc1d08dd627f5bb6e9569b84bcce622040a41fb#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-
-            var validateUrl = function(){
-                return personaClient.isPresignedUrlValid(urlToValidate, null);
-            };
-
-            validateUrl.should.throw("You must provide a secret with which to validate the url");
-            done();
-
-        });
-
-        it("should validate a presigned URL with no querystring or hash parameters", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var baseUrl = 'http://192.168.10.62:3000/player';
-            var expiry = new Date().getTime() + 86400;
-
-            var urlWithExp = baseUrl + '?expires=' + expiry;
-
-            var hash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var urlToValidate = baseUrl + '?expires=' + expiry + '&signature=' + hash;
-
-            var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
-
-            result.should.equal(true);
-
-            done();
-        });
-
-        it("should validate a presigned URL", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var urlToSign = baseUrl + urlHash;
-            var expiry = new Date().getTime() + 86400;
-
-            var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
-
-            var hash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var urlToValidate = baseUrl + '&expires=' + expiry + '&signature=' + hash + urlHash;
-
-            var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
-
-            result.should.equal(true);
-
-            done();
-        });
-
-        it("should validate a presigned URL has an expiry", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var urlToSign = baseUrl + urlHash;
-            var hash = cryptojs.HmacSHA256(urlToSign, secret);
-
-            var urlToValidate = baseUrl + '&signature=' + hash + urlHash;
-
-            var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
-
-            result.should.equal(false);
-
-            done();
-        });
-
-        it("should validate a presigned URL has expired", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var urlToSign = baseUrl + urlHash;
-            var expiry = Math.floor(new Date().getTime()/1000) - 5;
-
-            var urlWithExp = baseUrl + '&expires=' + expiry + urlHash;
-
-            var hash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var urlToValidate = baseUrl + '&expires=' + expiry + '&signature=' + hash + urlHash;
-
-            var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
-
-            result.should.equal(false);
-
-            done();
-        });
-
-        it("should validate a presigned URL is invalid", function(done){
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            var urlHash = '#/modules/52d01975d705e4730100000a/resources/5322e5413c53585456000006';
-            var baseUrl = 'http://192.168.10.62:3000/player?shortcode=google';
-            var urlToSign = baseUrl + urlHash;
-            var expiry = new Date().getTime() + 86400;
-
-            var urlWithExp = baseUrl + '&expiry=' + expiry + urlHash + '23'; // add additional data that will cause an invalid hash to be generated
-
-            var hash = cryptojs.HmacSHA256(urlWithExp, secret);
-
-            var urlToValidate = baseUrl + '&expiry=' + expiry + '&signature=' + hash + urlHash;
-
-            var result = personaClient.isPresignedUrlValid(urlToValidate, secret);
-
-            result.should.equal(false);
-
-            done();
-        });
-
-    });
 });

--- a/test/responses/user_scope/should_return_no_error_if_add_scope_successful.json
+++ b/test/responses/user_scope/should_return_no_error_if_add_scope_successful.json
@@ -1,6 +1,33 @@
 [
     {
         "scope": "http://persona:80",
+        "method": "POST",
+        "path": "/oauth/tokens",
+        "body": "grant_type=client_credentials",
+        "status": 200,
+        "response": {
+            "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIyNTIzNDEwODFlOTRmZGNiMWY0MjcyNmFjMGZjOWI3NDk5YTMwZGE1IiwiaWF0IjoxNDU2MzIyMDExLCJleHAiOjE0NTYzMjU2MTEsImF1ZCI6InByaW1hdGUiLCJzY29wZXMiOlsic3UiLCJwcmltYXRlIl19.gkQ0tqA2ClncMxRYubpVVkil28EywP21QIdYdI1eRxQFc0emDU65oKji1Hp9Fm51lWHWxjF8pP5t6qPW9-gtv-Hr6D8QuayiwJKVxCcI_PZyR3MK3u4-sC2B23n3SFpi45YeyL7ivKMNooBosztkIJk7eIO460q29VKtAGBY_oN2fgTaT2A2dreCe4_KNPo5m5Myk4zopCs5p6aKdCdaMtaDfPWLjr5w1AIa_dMQOlNPV_LJ0zJ0tcDRObTV6g4gBlySdxpovu8dWkMXYbysm6nGy_koNHYK-dgglCr1SWUjIxDxeOJU_b8NmiaaWZwoLh-XAQ9tsJ88DZaHMuiRpQ",
+            "expires_in": 3600,
+            "token_type": "bearer",
+            "scope": "su primate"
+        },
+        "headers": {
+            "date": "Wed, 24 Feb 2016 13:53:31 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=t5ncup6piugmgtbvmu5qpi04m0; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-store",
+            "pragma": "no-cache",
+            "content-length": "628",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "scope": "http://persona:80",
         "method": "PATCH",
         "path": "/1/clients/fdgNy6QWGmIAl7BRjEsFtk",
         "body": {

--- a/test/responses/user_scope/should_return_no_error_if_remove_scope_successful.json
+++ b/test/responses/user_scope/should_return_no_error_if_remove_scope_successful.json
@@ -1,6 +1,33 @@
 [
     {
         "scope": "http://persona:80",
+        "method": "POST",
+        "path": "/oauth/tokens",
+        "body": "grant_type=client_credentials",
+        "status": 200,
+        "response": {
+            "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIyNTIzNDEwODFlOTRmZGNiMWY0MjcyNmFjMGZjOWI3NDk5YTMwZGE1IiwiaWF0IjoxNDU2MzIyMDExLCJleHAiOjE0NTYzMjU2MTEsImF1ZCI6InByaW1hdGUiLCJzY29wZXMiOlsic3UiLCJwcmltYXRlIl19.gkQ0tqA2ClncMxRYubpVVkil28EywP21QIdYdI1eRxQFc0emDU65oKji1Hp9Fm51lWHWxjF8pP5t6qPW9-gtv-Hr6D8QuayiwJKVxCcI_PZyR3MK3u4-sC2B23n3SFpi45YeyL7ivKMNooBosztkIJk7eIO460q29VKtAGBY_oN2fgTaT2A2dreCe4_KNPo5m5Myk4zopCs5p6aKdCdaMtaDfPWLjr5w1AIa_dMQOlNPV_LJ0zJ0tcDRObTV6g4gBlySdxpovu8dWkMXYbysm6nGy_koNHYK-dgglCr1SWUjIxDxeOJU_b8NmiaaWZwoLh-XAQ9tsJ88DZaHMuiRpQ",
+            "expires_in": 3600,
+            "token_type": "bearer",
+            "scope": "su primate"
+        },
+        "headers": {
+            "date": "Wed, 24 Feb 2016 13:53:31 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=t5ncup6piugmgtbvmu5qpi04m0; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-store",
+            "pragma": "no-cache",
+            "content-length": "628",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "scope": "http://persona:80",
         "method": "PATCH",
         "path": "/1/clients/fdgNy6QWGmIAl7BRjEsFtk",
         "body": {

--- a/test/responses/user_scope/should_return_scopes_if_guid_is_valid.json
+++ b/test/responses/user_scope/should_return_scopes_if_guid_is_valid.json
@@ -1,6 +1,33 @@
 [
     {
         "scope": "http://persona:80",
+        "method": "POST",
+        "path": "/oauth/tokens",
+        "body": "grant_type=client_credentials",
+        "status": 200,
+        "response": {
+            "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIyNTIzNDEwODFlOTRmZGNiMWY0MjcyNmFjMGZjOWI3NDk5YTMwZGE1IiwiaWF0IjoxNDU2MzIyMDExLCJleHAiOjE0NTYzMjU2MTEsImF1ZCI6InByaW1hdGUiLCJzY29wZXMiOlsic3UiLCJwcmltYXRlIl19.gkQ0tqA2ClncMxRYubpVVkil28EywP21QIdYdI1eRxQFc0emDU65oKji1Hp9Fm51lWHWxjF8pP5t6qPW9-gtv-Hr6D8QuayiwJKVxCcI_PZyR3MK3u4-sC2B23n3SFpi45YeyL7ivKMNooBosztkIJk7eIO460q29VKtAGBY_oN2fgTaT2A2dreCe4_KNPo5m5Myk4zopCs5p6aKdCdaMtaDfPWLjr5w1AIa_dMQOlNPV_LJ0zJ0tcDRObTV6g4gBlySdxpovu8dWkMXYbysm6nGy_koNHYK-dgglCr1SWUjIxDxeOJU_b8NmiaaWZwoLh-XAQ9tsJ88DZaHMuiRpQ",
+            "expires_in": 3600,
+            "token_type": "bearer",
+            "scope": "su primate"
+        },
+        "headers": {
+            "date": "Wed, 24 Feb 2016 13:53:31 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=t5ncup6piugmgtbvmu5qpi04m0; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-store",
+            "pragma": "no-cache",
+            "content-length": "628",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "scope": "http://persona:80",
         "method": "GET",
         "path": "/1/clients/fdgNy6QWGmIAl7BRjEsFtk",
         "body": "",

--- a/test/responses/user_scope/should_throw_an_error_if_guid_is_not_valid.json
+++ b/test/responses/user_scope/should_throw_an_error_if_guid_is_not_valid.json
@@ -1,6 +1,33 @@
 [
     {
         "scope": "http://persona:80",
+        "method": "POST",
+        "path": "/oauth/tokens",
+        "body": "grant_type=client_credentials",
+        "status": 200,
+        "response": {
+            "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIyNTIzNDEwODFlOTRmZGNiMWY0MjcyNmFjMGZjOWI3NDk5YTMwZGE1IiwiaWF0IjoxNDU2MzIyMDExLCJleHAiOjE0NTYzMjU2MTEsImF1ZCI6InByaW1hdGUiLCJzY29wZXMiOlsic3UiLCJwcmltYXRlIl19.gkQ0tqA2ClncMxRYubpVVkil28EywP21QIdYdI1eRxQFc0emDU65oKji1Hp9Fm51lWHWxjF8pP5t6qPW9-gtv-Hr6D8QuayiwJKVxCcI_PZyR3MK3u4-sC2B23n3SFpi45YeyL7ivKMNooBosztkIJk7eIO460q29VKtAGBY_oN2fgTaT2A2dreCe4_KNPo5m5Myk4zopCs5p6aKdCdaMtaDfPWLjr5w1AIa_dMQOlNPV_LJ0zJ0tcDRObTV6g4gBlySdxpovu8dWkMXYbysm6nGy_koNHYK-dgglCr1SWUjIxDxeOJU_b8NmiaaWZwoLh-XAQ9tsJ88DZaHMuiRpQ",
+            "expires_in": 3600,
+            "token_type": "bearer",
+            "scope": "su primate"
+        },
+        "headers": {
+            "date": "Wed, 24 Feb 2016 13:53:31 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=t5ncup6piugmgtbvmu5qpi04m0; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-store",
+            "pragma": "no-cache",
+            "content-length": "628",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "scope": "http://persona:80",
         "method": "GET",
         "path": "/1/clients/guid",
         "body": "",

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -12,411 +12,74 @@ var _getStubResponse = require("./utils")._getStubResponse;
 var guid = require("./utils").guid;
 var runBeforeEach = require("./utils").beforeEach;
 var runAfterEach = require("./utils").afterEach;
+var leche = require("leche");
+var withData = leche.withData;
 
 describe("Persona Client Test Suite - Token Validation Tests", function() {
 
     var personaClient;
-    var privateKey = fs.readFileSync(__dirname + "/keys/privkey.pem");
-    var publicKey = fs.readFileSync(__dirname + "/keys/pubkey.pem");
-
-    beforeEach(function(done) {
-        runBeforeEach(this.currentTest.title, "token_validation");
-
-        personaClient = persona.createClient({
-            persona_host: "persona",
-            persona_port: 80,
-            persona_scheme: "http",
+    var privateKey = fs.readFileSync(__dirname + "/keys/privkey.pem", "utf-8");
+    var publicKey = fs.readFileSync(__dirname + "/keys/pubkey.pem", "utf-8");
+    withData({
+        "default-cache": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            enable_debug: false
+        },
+        "redis": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            cache: {
+                module: "redis",
+                options: {
+                    redisData: {
+                        hostname: "localhost",
+                        port: 6379,
+                        detect_buffers: true,
+                        return_buffers: true
+                    }
+                }
+            },
+            enable_debug: false
+        },
+        "legacy-config-options": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
             enable_debug: false
-        });
+        }
+    }, function(personaClientConfig) {
+        beforeEach(function(done) {
+            runBeforeEach(this.currentTest.title, "token_validation");
 
-        // Some tests rely on the cache being in a clean state
-        personaClient.redisClient.flushdb(function onFlushed() {
-           done();
-        });
-    });
-
-    afterEach(function() {
-        runAfterEach(this.currentTest.title, "token_validation");
-    });
-
-    it("should not validate an invalid token", function(done) {
-        var req = _getStubRequest("skldfjlskj", null);
-        var res = _getStubResponse();
-
-        // the callback wont be called internally because this is middleware
-        // therefore we need to call validate token and wait a couple of seconds for the
-        // request to fail and assert the response object
-        personaClient.validateHTTPBearerToken(req, res, function() {
-            done("validation passed when it should not have");
-        });
-        setTimeout(function(){
-            res._statusWasCalled.should.equal(true);
-            res._jsonWasCalled.should.equal(true);
-            res._setWasCalled.should.equal(true);
-
-            res._status.should.equal(401);
-            res._json.error.should.equal("invalid_token");
-            res._json.error_description.should.equal("The token is invalid or has expired");
-
-            done();
-        }, 2000);
-    });
-
-    it("should validate a token without scope", function(done) {
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, null);
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function(err, result) {
-                assert.equal(res._statusWasCalled, false);
-                assert.equal(res._jsonWasCalled, false);
-                assert.equal(res._setWasCalled, false);
-
-                assert.equal(result, "ok");
+            personaClient = persona.createClient(personaClientConfig);
+            sinon.spy(personaClient.http, "request");
+            // Some tests rely on the cache being in a clean state
+            personaClient.tokenCache.flush(function onFlushed() {
                 done();
             });
         });
-    });
 
-    it("should validate a scoped token", function(done) {
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "standard_user");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function(err, result) {
-                assert.equal(res._statusWasCalled, false);
-                assert.equal(res._jsonWasCalled, false);
-                assert.equal(res._setWasCalled, false);
-
-                assert.equal(result, "ok");
-                done();
-            });
+        afterEach(function() {
+            runAfterEach(this.currentTest.title, "token_validation");
+            personaClient.http.request.restore();
         });
-    });
 
-    it("should not validate an invalid scoped token", function(done) {
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "wibble");
+        it("should not validate an invalid token", function(done) {
+            var req = _getStubRequest("skldfjlskj", null);
             var res = _getStubResponse();
 
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function(){
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(403);
-                res._json.error.should.equal("insufficient_scope");
-                res._json.error_description.should.equal("The supplied token is missing a required scope");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should not validate an expired token", function(done) {
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1",
-            audience: "standard_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "standard_user");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function() {
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(401);
-                res._json.error.should.equal("invalid_token");
-                res._json.error_description.should.equal("The token is invalid or has expired");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should validate a token with su scope, even when it is not asked for", function(done) {
-        var payload = {
-            scopes: [
-                "su",
-                "super_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "super_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "other_scope");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function(err, result) {
-                assert.equal(res._statusWasCalled, false);
-                assert.equal(res._jsonWasCalled, false);
-                assert.equal(res._setWasCalled, false);
-
-                assert.equal(result, "ok");
-                done();
-            });
-        });
-    });
-
-    it("should validate a scoped token when the list of scopes is too many to return", function(done) {
-        var payload = {
-            scopeCount: 26
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "fatuser"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            // We can't replay the recorded response as the token in that request will expire
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(204);
-
-            var req = _getStubRequest(token, "fatuser");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function(error, result) {
-                if(error) {
-                    return done(error);
-                }
-                assert.equal(res._statusWasCalled, false);
-                assert.equal(res._jsonWasCalled, false);
-                assert.equal(res._setWasCalled, false);
-
-                assert.equal(result, "ok");
-                done();
-            });
-        });
-    });
-
-    it("should validate a token with su scope when checked via persona, even when it is not asked for", function(done) {
-        var payload = {
-            scopeCount: 26
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "fatuser"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            // First respond that the scope is insufficient then respond ok for su
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=other_scope/).reply(403);
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=su/).reply(204);
-
-            var req = _getStubRequest(token, "other_scope");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function(err, result) {
-                assert.equal(res._statusWasCalled, false);
-                assert.equal(res._jsonWasCalled, false);
-                assert.equal(res._setWasCalled, false);
-
-                assert.equal(result, "ok");
-                done();
-            });
-        });
-    });
-
-    it("should not validate an invalid scoped token when the list of scopes is too many to return", function(done) {
-        var payload = {
-            scopeCount: 26
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "fatuser"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            // We can't replay the recorded response as the token in that request will expire
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=invalid/).reply(403);
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=su/).reply(403);
-
-            var req = _getStubRequest(token, "invalid");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function() {
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(403);
-                res._json.error.should.equal("insufficient_scope");
-                res._json.error_description.should.equal("The supplied token is missing a required scope");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should not validate a token when the server-side check returns 401", function(done) {
-        var payload = {
-            scopeCount: 26
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "fatuser"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            // We can't replay the recorded response as the token in that request will expire
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(401);
-
-            var req = _getStubRequest(token, "fatuser");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function() {
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(401);
-                res._json.error.should.equal("invalid_token");
-                res._json.error_description.should.equal("The token is invalid or has expired");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should not validate a token when the server-side check returns an error", function(done) {
-        var payload = {
-            scopeCount: 26
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "fatuser"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            // We can't replay the recorded response as the token in that request will expire
-            nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(500);
-
-            var req = _getStubRequest(token, "fatuser");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function() {
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(500);
-                res._json.error.should.equal("unexpected_error");
-                res._json.error_description.should.equal("communication_issue");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should not validate a token when the public key is incorrect", function(done) {
-        // stub response file contains a public key that has been tampered with.
-
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
-
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "standard_user");
-            var res = _getStubResponse();
-
+            // the callback wont be called internally because this is middleware
+            // therefore we need to call validate token and wait a couple of seconds for the
+            // request to fail and assert the response object
             personaClient.validateHTTPBearerToken(req, res, function() {
                 done("validation passed when it should not have");
             });
@@ -432,61 +95,21 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 done();
             }, 2000);
         });
-    });
 
-    it("should not validate a token when there is a problem fetching the public key", function(done) {
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
+        it("should validate a token without scope", function(done) {
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
 
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
 
-        jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
-            var req = _getStubRequest(token, "standard_user");
-            var res = _getStubResponse();
-
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function(){
-                res._statusWasCalled.should.equal(true);
-                res._jsonWasCalled.should.equal(true);
-                res._setWasCalled.should.equal(true);
-
-                res._status.should.equal(500);
-                res._json.error.should.equal("unexpected_error");
-                res._json.error_description.should.equal("communication_issue");
-
-                done();
-            }, 2000);
-        });
-    });
-
-    it("should use a cached public key when validating a token", function(done) {
-        sinon.spy(personaClient.http, "request");
-
-        var payload = {
-            scopes: [
-                "standard_user"
-            ]
-        };
-
-        var jwtSigningOptions = {
-            jwtid: guid(),
-            algorithm: "RS256",
-            expiresIn: "1h",
-            audience: "standard_user"
-        };
-
-        // First make sure the cache has the key
-        personaClient.redisClient.set("public_key", publicKey, function() {
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
@@ -497,8 +120,414 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._setWasCalled, false);
 
                     assert.equal(result, "ok");
+                    done();
+                });
+            });
+        });
+
+        it("should validate a scoped token", function(done) {
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "standard_user");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                    assert.equal(res._statusWasCalled, false);
+                    assert.equal(res._jsonWasCalled, false);
+                    assert.equal(res._setWasCalled, false);
+
+                    assert.equal(result, "ok");
+                    done();
+                });
+            });
+        });
+
+        it("should not validate an invalid scoped token", function(done) {
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "wibble");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function(){
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(403);
+                    res._json.error.should.equal("insufficient_scope");
+                    res._json.error_description.should.equal("The supplied token is missing a required scope");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should not validate an expired token", function(done) {
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1",
+                audience: "standard_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "standard_user");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function() {
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(401);
+                    res._json.error.should.equal("invalid_token");
+                    res._json.error_description.should.equal("The token is invalid or has expired");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should validate a token with su scope, even when it is not asked for", function(done) {
+            var payload = {
+                scopes: [
+                    "su",
+                    "super_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "super_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "other_scope");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                    assert.equal(res._statusWasCalled, false);
+                    assert.equal(res._jsonWasCalled, false);
+                    assert.equal(res._setWasCalled, false);
+
+                    assert.equal(result, "ok");
+                    done();
+                });
+            });
+        });
+
+        it("should validate a scoped token when the list of scopes is too many to return", function(done) {
+            var payload = {
+                scopeCount: 26
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "fatuser"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                // We can't replay the recorded response as the token in that request will expire
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(204);
+
+                var req = _getStubRequest(token, "fatuser");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function(error, result) {
+                    if(error) {
+                        return done(error);
+                    }
+                    assert.equal(res._statusWasCalled, false);
+                    assert.equal(res._jsonWasCalled, false);
+                    assert.equal(res._setWasCalled, false);
+
+                    assert.equal(result, "ok");
+                    done();
+                });
+            });
+        });
+
+        it("should validate a token with su scope when checked via persona, even when it is not asked for", function(done) {
+            var payload = {
+                scopeCount: 26
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "fatuser"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                // First respond that the scope is insufficient then respond ok for su
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=other_scope/).reply(403);
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=su/).reply(204);
+
+                var req = _getStubRequest(token, "other_scope");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                    assert.equal(res._statusWasCalled, false);
+                    assert.equal(res._jsonWasCalled, false);
+                    assert.equal(res._setWasCalled, false);
+
+                    assert.equal(result, "ok");
+                    done();
+                });
+            });
+        });
+
+        it("should not validate an invalid scoped token when the list of scopes is too many to return", function(done) {
+            var payload = {
+                scopeCount: 26
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "fatuser"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                // We can't replay the recorded response as the token in that request will expire
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=invalid/).reply(403);
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=su/).reply(403);
+
+                var req = _getStubRequest(token, "invalid");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function() {
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(403);
+                    res._json.error.should.equal("insufficient_scope");
+                    res._json.error_description.should.equal("The supplied token is missing a required scope");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should not validate a token when the server-side check returns 401", function(done) {
+            var payload = {
+                scopeCount: 26
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "fatuser"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                // We can't replay the recorded response as the token in that request will expire
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(401);
+
+                var req = _getStubRequest(token, "fatuser");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function() {
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(401);
+                    res._json.error.should.equal("invalid_token");
+                    res._json.error_description.should.equal("The token is invalid or has expired");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should not validate a token when the server-side check returns an error", function(done) {
+            var payload = {
+                scopeCount: 26
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "fatuser"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                // We can't replay the recorded response as the token in that request will expire
+                nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(500);
+
+                var req = _getStubRequest(token, "fatuser");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function() {
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(500);
+                    res._json.error.should.equal("unexpected_error");
+                    res._json.error_description.should.equal("communication_issue");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should not validate a token when the public key is incorrect", function(done) {
+            // stub response file contains a public key that has been tampered with.
+
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "standard_user");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function(){
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(401);
+                    res._json.error.should.equal("invalid_token");
+                    res._json.error_description.should.equal("The token is invalid or has expired");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should not validate a token when there is a problem fetching the public key", function(done) {
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
+
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, "standard_user");
+                var res = _getStubResponse();
+
+                personaClient.validateHTTPBearerToken(req, res, function() {
+                    done("validation passed when it should not have");
+                });
+                setTimeout(function(){
+                    res._statusWasCalled.should.equal(true);
+                    res._jsonWasCalled.should.equal(true);
+                    res._setWasCalled.should.equal(true);
+
+                    res._status.should.equal(500);
+                    res._json.error.should.equal("unexpected_error");
+                    res._json.error_description.should.equal("communication_issue");
+
+                    done();
+                }, 2000);
+            });
+        });
+
+        it("should use a cached public key when validating a token", function(done) {
+
+
+            var payload = {
+                scopes: [
+                    "standard_user"
+                ]
+            };
+
+            var jwtSigningOptions = {
+                jwtid: guid(),
+                algorithm: "RS256",
+                expiresIn: "1h",
+                audience: "standard_user"
+            };
+
+            // First make sure the cache has the key
+            personaClient.tokenCache.set("public_key", publicKey);
+            jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                var req = _getStubRequest(token, null);
+                var res = _getStubResponse();
+                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                    assert.equal(res._statusWasCalled, false);
+                    assert.equal(res._jsonWasCalled, false);
+                    assert.equal(res._setWasCalled, false);
+
+                    assert.equal(result, "ok");
                     assert.equal(personaClient.http.request.called, false);
-                    personaClient.http.request.restore();
+
                     done();
                 });
             });

--- a/test/user_scope_tests.js
+++ b/test/user_scope_tests.js
@@ -5,509 +5,343 @@ var assert = require("assert");
 var persona = require("../index");
 var runBeforeEach = require("./utils").beforeEach;
 var runAfterEach = require("./utils").afterEach;
+var leche = require("leche");
+var withData = leche.withData;
 
 describe("Persona Client Test Suite - User Scope Tests", function() {
 
-    beforeEach(function() {
-        runBeforeEach(this.currentTest.title, "user_scope");
-    });
+    var oauthClient = process.env.PERSONA_TEST_OAUTH_CLIENT || "primate";
+    var oauthSecret = process.env.PERSONA_TEST_OAUTH_SECRET || "bananas";
 
-    afterEach(function() {
-        runAfterEach(this.currentTest.title, "user_scope");
-    });
-
-    describe("- Get user scopes tests", function() {
-        it("should throw an error if guid is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.getScopesForUser(null,"token",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid and token are required strings");
-                assert(data == null);
-                done();
-            });
+    withData({
+        "default-cache": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            enable_debug: false
+        },
+        "redis": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            cache: {
+                module: "redis",
+                options: {
+                    redisData: {
+                        hostname: "localhost",
+                        port: 6379
+                    }
+                }
+            },
+            enable_debug: false
+        },
+        "legacy-config-options": {
+            persona_host: process.env.PERSONA_TEST_HOST || "persona",
+            persona_port: process.env.PERSONA_TEST_PORT || 80,
+            persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
+            persona_oauth_route: "/oauth/tokens/",
+            redis_host: "localhost",
+            redis_port: 6379,
+            redis_db: 0,
+            enable_debug: false
+        }
+    }, function(personaClientConfig) {
+        beforeEach(function() {
+            runBeforeEach(this.currentTest.title, "user_scope");
         });
 
-        it("should throw an error if guid is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.getScopesForUser({},"token",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid and token are required strings");
-                assert(data == null);
-                done();
-            });
+        afterEach(function() {
+            runAfterEach(this.currentTest.title, "user_scope");
         });
 
-        it("should throw an error if token is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
+        describe("- Get user scopes tests", function() {
+            it("should throw an error if guid is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            personaClient.getScopesForUser("guid",null,function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid and token are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if token is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.getScopesForUser("guid",{},function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid and token are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if guid is not valid", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.obtainToken("primate","bananas",function(err,data1) {
-                personaClient.getScopesForUser("guid",data1.access_token,function(err,data) {
+                personaClient.getScopesForUser(null,"token",function(err,data) {
                     assert(err != null);
                     err.should.be.a.String;
-                    err.should.equal("getScopesForUser failed with status code 404");
+                    err.should.equal("guid and token are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if guid is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.getScopesForUser({},"token",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid and token are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if token is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.getScopesForUser("guid",null,function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid and token are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if token is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.getScopesForUser("guid",{},function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid and token are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if guid is not valid", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.obtainToken(oauthClient, oauthSecret, function(err, data1) {
+                    personaClient.getScopesForUser("guid", data1.access_token, function(err, data) {
+                        assert(err != null);
+                        err.should.be.a.String;
+                        err.should.equal("getScopesForUser failed with status code 404");
+                        assert(data == null);
+                        done();
+                    });
+                });
+            });
+
+            it("should return scopes if guid is valid", function(done) {
+                var data = {scope:['fdgNy6QWGmIAl7BRjEsFtk','tdc:app:access','tdc:player:access']};
+                var expected = data.scope;
+
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.obtainToken(oauthClient, oauthSecret, function(err, data1) {
+                    personaClient.getScopesForUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, function(err, data) {
+                        assert(err == null);
+                        assert(data != null);
+                        data.should.be.an.instanceOf(Array).and.have.lengthOf(3);
+                        data.should.eql(expected);
+                        done();
+                    });
+                });
+            });
+
+            it("should return error if token is invalid", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.getScopesForUser('guid_does_exist', "invalid", function(err, data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("getScopesForUser failed with status code 401");
                     assert(data == null);
                     done();
                 });
             });
         });
 
-        it("should return scopes if guid is valid", function(done) {
-            var data = {scope:['fdgNy6QWGmIAl7BRjEsFtk','tdc:app:access','tdc:player:access']};
-            var expected = data.scope;
+        describe("- Add scope to user tests", function(){
+            it("should throw an error if guid is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.obtainToken("primate","bananas",function(err,data1) {
-                personaClient.getScopesForUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, function(err, data) {
-                    assert(err == null);
-                    assert(data != null);
-                    data.should.be.an.instanceOf(Array).and.have.lengthOf(3);
-                    data.should.eql(expected);
+                personaClient.addScopeToUser(null,"token","scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
                     done();
                 });
             });
-        });
 
-        it("should return error if token is invalid", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+            it("should throw an error if guid is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.addScopeToUser({},"token","scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.getScopesForUser('guid_does_exist', "invalid", function(err, data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("getScopesForUser failed with status code 401");
-                assert(data == null);
-                done();
-            });
-        });
-    });
+            it("should throw an error if token is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-    describe("- Add scope to user tests", function(){
-        it("should throw an error if guid is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                personaClient.addScopeToUser("guid",null,"scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.addScopeToUser(null,"token","scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
+            it("should throw an error if token is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-        it("should throw an error if guid is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                personaClient.addScopeToUser("guid",{},"scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.addScopeToUser({},"token","scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
+            it("should throw an error if scope is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-        it("should throw an error if token is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                personaClient.addScopeToUser("guid","token",null,function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.addScopeToUser("guid",null,"scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
+            it("should throw an error if scope is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-        it("should throw an error if token is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                personaClient.addScopeToUser("guid","token",{},function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.addScopeToUser("guid",{},"scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
+            it("should return no error if add scope successful", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-        it("should throw an error if scope is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+                personaClient.obtainToken(oauthClient, oauthSecret, function(err, data1) {
+                    personaClient.addScopeToUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, "test_scope", function(err, data){
+                        assert(err == null);
+                        assert(data == null);
+                        done();
+                    });
+                });
             });
 
-            personaClient.addScopeToUser("guid","token",null,function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
+            it("should return error if add scope fails with invalid token", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-        it("should throw an error if scope is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.addScopeToUser("guid","token",{},function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should return no error if add scope successful", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.obtainToken("primate","bananas",function(err,data1) {
-                personaClient.addScopeToUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, "test_scope", function(err, data){
-                    assert(err == null);
+                personaClient.addScopeToUser("fdgNy6QWGmIAl7BRjEsFtk", "invalid", "test_scope", function(err, data){
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("setScopesForUser failed with status code 401");
                     assert(data == null);
                     done();
                 });
             });
         });
 
-        it("should return error if add scope fails with invalid token", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
+        describe("- Remove scope from user tests", function(){
+            it("should throw an error if guid is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
 
-            personaClient.addScopeToUser("fdgNy6QWGmIAl7BRjEsFtk", "invalid", "test_scope", function(err, data){
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("setScopesForUser failed with status code 401");
-                assert(data == null);
-                done();
-            });
-        });
-    });
-
-    describe("- Remove scope from user tests", function(){
-        it("should throw an error if guid is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser(null,"token","scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if guid is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser({},"token","scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if token is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser("guid",null,"scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if token is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser("guid",{},"scope",function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if scope is not present", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser("guid","token",null,function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should throw an error if scope is not a string", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.removeScopeFromUser("guid","token",{},function(err,data) {
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("guid, token and scope are required strings");
-                assert(data == null);
-                done();
-            });
-        });
-
-        it("should return no error if remove scope successful", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
-            });
-
-            personaClient.obtainToken("primate","bananas",function(err,data1) {
-                personaClient.removeScopeFromUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, "test_scope", function(err, data){
-                    assert(err == null);
+                personaClient.removeScopeFromUser(null,"token","scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
                     assert(data == null);
                     done();
                 });
             });
-        });
 
-        it("should return error if remove scope fails with invalid token", function(done) {
-            var personaClient = persona.createClient({
-                persona_host:"persona",
-                persona_port:80,
-                persona_scheme:"http",
-                persona_oauth_route:"/oauth/tokens/",
-                redis_host:"localhost",
-                redis_port:6379,
-                redis_db:0,
-                enable_debug: false
+            it("should throw an error if guid is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser({},"token","scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
             });
 
-            personaClient.removeScopeFromUser('fdgNy6QWGmIAl7BRjEsFtk', "invalid", "test_scope", function(err, data){
-                assert(err != null);
-                err.should.be.a.String;
-                err.should.equal("setScopesForUser failed with status code 401");
-                assert(data == null);
-                done();
+            it("should throw an error if token is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser("guid",null,"scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if token is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser("guid",{},"scope",function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if scope is not present", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser("guid","token",null,function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should throw an error if scope is not a string", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser("guid","token",{},function(err,data) {
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("guid, token and scope are required strings");
+                    assert(data == null);
+                    done();
+                });
+            });
+
+            it("should return no error if remove scope successful", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.obtainToken(oauthClient, oauthSecret, function(err, data1) {
+                    personaClient.removeScopeFromUser('fdgNy6QWGmIAl7BRjEsFtk', data1.access_token, "test_scope", function(err, data){
+                        assert(err == null);
+                        assert(data == null);
+                        done();
+                    });
+                });
+            });
+
+            it("should return error if remove scope fails with invalid token", function(done) {
+                var personaClient = persona.createClient(personaClientConfig);
+
+                personaClient.removeScopeFromUser('fdgNy6QWGmIAl7BRjEsFtk', "invalid", "test_scope", function(err, data){
+                    assert(err != null);
+                    err.should.be.a.String;
+                    err.should.equal("setScopesForUser failed with status code 401");
+                    assert(data == null);
+                    done();
+                });
             });
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -117,6 +117,8 @@ var beforeEach = function recordOrReplayHttpCalls(testFriendlyName, responsesFol
 };
 
 var afterEach = function recordAndSaveHttpCallsIfEnabled(testFriendlyName, responsesFolder) {
+    // Removes any unused requests so that they don't leak into other tests.
+    nock.cleanAll();
     if(process.env.RECORD_HTTP_CALLS === "true") {
         var testName = testFriendlyName.replace(/ /g, "_");
         var fileName = __dirname + "/responses/" + responsesFolder + "/" + testName + ".json";


### PR DESCRIPTION
This replaces the redis dependency with a cache abstraction layer (cache-service).

It’s designed to be completely backward compatible, so the old initialization object, although deprecated, should still work for now and automatically set up cache-service-redis