### PR TITLE
90% - Background Certificate Retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var ERROR_TYPES = {
  * config.enable_debug : true|false
  * config.logger: <pass in a logger that has debug() and error() functions>
  * config.cache: { module: <redis|node-cache>, options: <cache-service-options> }
- * config.cert_background_refresh: true|false
+ * config.cert_background_refresh: true|false defaults to true
  *
  * deprecated params:
  * config.redis_host
@@ -94,7 +94,7 @@ var PersonaClient = function (config) {
     // need to instantiate this based on the configured scheme
     this.http = require(this.config.persona_scheme);
 
-    if (this.config.cert_background_refresh === true) {
+    if (this.config.cert_background_refresh !== true) {
         this.getPublicKey(function retrievedCert() {
             setInterval(function refreshCert() {
                 this.getPublicKey(function retrievedPublicKey() {

--- a/index.js
+++ b/index.js
@@ -1082,6 +1082,8 @@ PersonaClient.prototype.error = function (message) {
     this.log(ERROR, message);
 };
 
+exports.errorTypes = ERROR_TYPES;
+
 /**
  * The only way to get an instance of the Persona Client is through
  * this method
@@ -1091,3 +1093,4 @@ PersonaClient.prototype.error = function (message) {
 exports.createClient = function (config) {
     return new PersonaClient(config);
 };
+

--- a/index.js
+++ b/index.js
@@ -94,14 +94,14 @@ var PersonaClient = function (config) {
     // need to instantiate this based on the configured scheme
     this.http = require(this.config.persona_scheme);
 
-    if (this.config.cert_background_refresh !== true) {
+    if (this.config.cert_background_refresh !== false) {
         this.getPublicKey(function retrievedCert() {
             setInterval(function refreshCert() {
                 this.getPublicKey(function retrievedPublicKey() {
                     log('debug', 'retrieved public key');
                 }, true);
-            }, PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
-        });
+            }.bind(this), PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
+        }.bind(this));
     }
 
     this.log('debug', "Persona Client Created");

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ var PersonaClient = function (config) {
 /**
  * Retrieve Persona's public key that is used to sign the JWTs.
  * @param {callback} cb function(err, publicCert)
- * @param {boolean=} refresh (optional) refresh the token
+ * @param {boolean=} refresh (optional) refresh the certificate
  */
 PersonaClient.prototype.getPublicKey = function getPublicKey(cb, refresh) {
     var log = this.log.bind(this);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var CacheService = require("cache-service");
 
 var PUBLIC_KEY_CACHE_NAME = "public_key";
 var CACHE_TIMEOUT = 60 * 10;
-var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 9;
+//var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 9;
 
 // log severities
 var DEBUG = "debug";
@@ -94,15 +94,15 @@ var PersonaClient = function (config) {
     // need to instantiate this based on the configured scheme
     this.http = require(this.config.persona_scheme);
 
-    if (this.config.cert_background_refresh !== false) {
-        this.getPublicKey(function retrievedCert() {
-            setInterval(function refreshCert() {
-                this.getPublicKey(function retrievedPublicKey() {
-                    log('debug', 'retrieved public key');
-                }, true);
-            }.bind(this), PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
-        }.bind(this));
-    }
+    //if (this.config.cert_background_refresh !== false) {
+        //this.getPublicKey(function retrievedCert() {
+            //setInterval(function refreshCert() {
+                //this.getPublicKey(function retrievedPublicKey() {
+                    //log('debug', 'retrieved public key');
+                //}, true);
+            //}.bind(this), PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
+        //}.bind(this));
+    //}
 
     this.log('debug', "Persona Client Created");
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var CacheService = require("cache-service");
 
 var PUBLIC_KEY_CACHE_NAME = "public_key";
 var CACHE_TIMEOUT = 60 * 10;
-var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 9;
+var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 7;
 
 // log severities
 var DEBUG = "debug";

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ var PersonaClient = function (config) {
 /**
  * Retrieve Persona's public key that is used to sign the JWTs.
  * @param {callback} cb function(err, publicCert)
- * @param {boolean=} refresh (optional) refresh the certificate
+ * @param {boolean=} refresh (optional) refresh the public key
  */
 PersonaClient.prototype.getPublicKey = function getPublicKey(cb, refresh) {
     var log = this.log.bind(this);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var CacheService = require("cache-service");
 
 var PUBLIC_KEY_CACHE_NAME = "public_key";
 var CACHE_TIMEOUT = 60 * 10;
-//var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 9;
+var PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 60 * 9;
 
 // log severities
 var DEBUG = "debug";
@@ -94,15 +94,15 @@ var PersonaClient = function (config) {
     // need to instantiate this based on the configured scheme
     this.http = require(this.config.persona_scheme);
 
-    //if (this.config.cert_background_refresh !== false) {
-        //this.getPublicKey(function retrievedCert() {
-            //setInterval(function refreshCert() {
-                //this.getPublicKey(function retrievedPublicKey() {
-                    //log('debug', 'retrieved public key');
-                //}, true);
-            //}.bind(this), PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
-        //}.bind(this));
-    //}
+    if (this.config.cert_background_refresh !== false) {
+        this.getPublicKey(function retrievedCert() {
+            this.refreshTimerId = setInterval(function refreshCert() {
+                this.getPublicKey(function retrievedPublicKey() {
+                    log('debug', 'retrieved public key');
+                }, true);
+            }.bind(this), PUBLIC_KEY_AUTO_REFRESH_TIMEOUT);
+        }.bind(this));
+    }
 
     this.log('debug', "Persona Client Created");
 };

--- a/test/authorization_tests.js
+++ b/test/authorization_tests.js
@@ -22,7 +22,8 @@ describe("Persona Client Test Suite - Authorization Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "redis": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -38,7 +39,8 @@ describe("Persona Client Test Suite - Authorization Tests", function() {
                     }
                 }
             },
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "legacy-config-options": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",

--- a/test/authorization_tests.js
+++ b/test/authorization_tests.js
@@ -48,7 +48,8 @@ describe("Persona Client Test Suite - Authorization Tests", function() {
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         }
     }, function(personaClientConfig) {
         beforeEach(function createClientAndStubs() {

--- a/test/persona_client_tests.js
+++ b/test/persona_client_tests.js
@@ -64,6 +64,7 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                     persona_port: 80,
                     persona_scheme: "http",
                     persona_oauth_route: "/oauth/tokens",
+                    cert_background_refresh: false,
                     cache: {
                         module: "redis",
                         options: {
@@ -91,7 +92,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                 persona_port: process.env.PERSONA_TEST_PORT || 80,
                 persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
                 persona_oauth_route: "/oauth/tokens/",
-                enable_debug: false
+                enable_debug: false,
+                cert_background_refresh: false,
             },
             "redis": {
                 persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -107,7 +109,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                         }
                     }
                 },
-                enable_debug: false
+                enable_debug: false,
+                cert_background_refresh: false,
             },
             "legacy-config-options": {
                 persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -117,7 +120,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                 redis_host: "localhost",
                 redis_port: 6379,
                 redis_db: 0,
-                enable_debug: false
+                enable_debug: false,
+                cert_background_refresh: false,
             }
         }, function(personaClientConfig) {
             beforeEach(function () {

--- a/test/presigned_url_tests.js
+++ b/test/presigned_url_tests.js
@@ -17,7 +17,8 @@ describe("Persona Client Test Suite - Presigned URL Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "redis": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -33,7 +34,8 @@ describe("Persona Client Test Suite - Presigned URL Tests", function() {
                     }
                 }
             },
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "legacy-config-options": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -43,7 +45,8 @@ describe("Persona Client Test Suite - Presigned URL Tests", function() {
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         }
     }, function(personaClientConfig) {
         beforeEach(function() {

--- a/test/responses/token_validation/should_retrieve_cert_straight_away_if_auto_update_is_on.json
+++ b/test/responses/token_validation/should_retrieve_cert_straight_away_if_auto_update_is_on.json
@@ -1,0 +1,25 @@
+[
+    {
+        "scope": "http://persona:80",
+        "method": "GET",
+        "path": "/oauth/keys",
+        "body": "",
+        "status": 200,
+        "response": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreNgSCIbujagRGpKXR9C\nrm/emoClGz5G6pGgP97A1+e9zmEX4f2PRu9dvAT3wa/BmGRmTcxlCFt6j+GXsVbP\n6Gs2W/p+fTI/b1AQQzThcGsbUfd7kjDDp+8t63SHGysoSXRbARevAb2BoUgPPySj\nirFYlZcMRWH8+TTJF4JTiX7EeTpnDzcqVppWB3zD6Qsqd3SxrWP8R1VbN0IaB1qa\nzU9vS63AL31GQI/MrYGcMYOMR935tx3a6MLkLQeKe7mqGSVoZXVNTD5hdr4ZwRHt\nRCJTNdFhIpte1BI4B3P0ggkFRLZwL0zbmpLBqtCp3h9Cdn7cm3Y25Jk0cPz7n8LS\n+QIDAQAB\n-----END PUBLIC KEY-----\n",
+        "headers": {
+            "date": "Fri, 26 Feb 2016 16:25:48 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=38o2ogbjc4nvnopqmo2a4tn375; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-cache, must-revalidate",
+            "pragma": "no-cache",
+            "vary": "Accept-Encoding",
+            "content-length": "451",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "text/plain;charset=utf-8"
+        }
+    }
+]

--- a/test/responses/token_validation/should_retrieve_cert_straight_away_if_auto_update_is_on.json
+++ b/test/responses/token_validation/should_retrieve_cert_straight_away_if_auto_update_is_on.json
@@ -21,5 +21,28 @@
             "connection": "Keep-Alive",
             "content-type": "text/plain;charset=utf-8"
         }
+    },
+    {
+        "scope": "http://persona:80",
+        "method": "GET",
+        "path": "/oauth/keys",
+        "body": "",
+        "status": 200,
+        "response": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAreNgSCIbujagRGpKXR9C\nrm/emoClGz5G6pGgP97A1+e9zmEX4f2PRu9dvAT3wa/BmGRmTcxlCFt6j+GXsVbP\n6Gs2W/p+fTI/b1AQQzThcGsbUfd7kjDDp+8t63SHGysoSXRbARevAb2BoUgPPySj\nirFYlZcMRWH8+TTJF4JTiX7EeTpnDzcqVppWB3zD6Qsqd3SxrWP8R1VbN0IaB1qa\nzU9vS63AL31GQI/MrYGcMYOMR935tx3a6MLkLQeKe7mqGSVoZXVNTD5hdr4ZwRHt\nRCJTNdFhIpte1BI4B3P0ggkFRLZwL0zbmpLBqtCp3h9Cdn7cm3Y25Jk0cPz7n8LS\n+QIDAQAB\n-----END PUBLIC KEY-----\n",
+        "headers": {
+            "date": "Fri, 26 Feb 2016 16:25:48 GMT",
+            "server": "Apache",
+            "set-cookie": [
+                "PHPSESSID=38o2ogbjc4nvnopqmo2a4tn375; path=/"
+            ],
+            "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+            "cache-control": "no-cache, must-revalidate",
+            "pragma": "no-cache",
+            "vary": "Accept-Encoding",
+            "content-length": "451",
+            "keep-alive": "timeout=5, max=100",
+            "connection": "Keep-Alive",
+            "content-type": "text/plain;charset=utf-8"
+        }
     }
 ]

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -93,7 +93,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             setTimeout(function fin() {
                 clearInterval(client.refreshTimerId);
                 return done();
-            }, 1000);
+            }, 3000);
         });
 
         it("should not validate an invalid token", function(done) {

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -87,13 +87,13 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             var config = lodash.clone(personaClientConfig);
             config.cert_background_refresh = true;
 
-            persona.PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 0.6;
+            persona.PUBLIC_KEY_AUTO_REFRESH_TIMEOUT = 1;
             var client = persona.createClient(config);
 
             setTimeout(function fin() {
                 clearInterval(client.refreshTimerId);
                 return done();
-            }, 3000);
+            }, 1500);
         });
 
         it("should not validate an invalid token", function(done) {

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -80,7 +80,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             // the callback wont be called internally because this is middleware
             // therefore we need to call validate token and wait a couple of seconds for the
             // request to fail and assert the response object
-            personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+            personaClient.validateHTTPBearerToken(req, res, function validatedToken(err) {
+                err.should.be.equal(persona.errorTypes.VALIDATION_FAILURE);
                 res._statusWasCalled.should.equal(true);
                 res._jsonWasCalled.should.equal(true);
                 res._setWasCalled.should.equal(true);
@@ -111,7 +112,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
+                    (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -140,7 +142,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
+                    (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -169,7 +172,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "wibble");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err) {
+                    err.should.be.equal(persona.errorTypes.INSUFFICIENT_SCOPE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -201,7 +205,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, success) {
+                    err.should.be.equal(persona.errorTypes.VALIDATION_FAILURE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -234,7 +239,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "other_scope");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
+                    (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -264,7 +270,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "fatuser");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(error, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(error, result) {
                     if(error) {
                         return done(error);
                     }
@@ -298,7 +304,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "other_scope");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
+                    (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -329,7 +336,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "invalid");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err) {
+                    err.should.be.equal(persona.errorTypes.INSUFFICIENT_SCOPE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -363,6 +371,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                    err.should.be.equal(persona.errorTypes.VALIDATION_FAILURE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -396,6 +405,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                    err.should.be.equal(persona.errorTypes.COMMUNICATION_ISSUE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -429,7 +439,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err) {
+                    err.should.be.equal(persona.errorTypes.VALIDATION_FAILURE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -462,7 +473,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, success) {
+                    err.should.be.equal(persona.errorTypes.COMMUNICATION_ISSUE);
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -495,7 +507,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
-                personaClient.validateHTTPBearerToken(req, res, function(err, result) {
+                personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
+                    (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -76,6 +76,15 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             personaClient.http.request.restore();
         });
 
+        it('should retrieve cert straight away if auto update is on', function(done) {
+            nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
+            personaClientConfig.cert_background_refresh = true;
+            persona.createClient(personaClientConfig);
+            setTimeout(function fin() {
+                return done();
+            }, 1000);
+        });
+
         it("should not validate an invalid token", function(done) {
             nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
             var req = _getStubRequest("skldfjlskj", null);

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -26,7 +26,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "redis": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -44,7 +45,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     }
                 }
             },
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "legacy-config-options": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -54,7 +56,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         }
     }, function(personaClientConfig) {
         beforeEach(function(done) {

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -93,7 +93,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             setTimeout(function fin() {
                 clearInterval(client.refreshTimerId);
                 return done();
-            }, 1500);
+            }, 3000);
         });
 
         it("should not validate an invalid token", function(done) {

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -355,6 +355,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
         });
 
         it("should not validate a token when the server-side check returns 401", function(done) {
+
             var payload = {
                 scopeCount: 26
             };
@@ -368,6 +369,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 // We can't replay the recorded response as the token in that request will expire
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
                 nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(401);
 
                 var req = _getStubRequest(token, "fatuser");
@@ -473,6 +475,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             };
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                nock('http://persona').get(/\/oauth\/keys/).reply(504);
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -77,6 +77,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
         });
 
         it("should not validate an invalid token", function(done) {
+            nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
             var req = _getStubRequest("skldfjlskj", null);
             var res = _getStubResponse();
 
@@ -112,6 +113,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             };
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
 
@@ -172,6 +174,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             };
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
                 var req = _getStubRequest(token, "wibble");
                 var res = _getStubResponse();
 
@@ -239,6 +242,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             };
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
                 var req = _getStubRequest(token, "other_scope");
                 var res = _getStubResponse();
 
@@ -269,6 +273,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 // We can't replay the recorded response as the token in that request will expire
                 nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=fatuser/).reply(204);
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
 
                 var req = _getStubRequest(token, "fatuser");
                 var res = _getStubResponse();
@@ -301,6 +306,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
 
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 // First respond that the scope is insufficient then respond ok for su
+                nock('http://persona').get(/\/oauth\/keys/).reply(200, publicKey);
                 nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=other_scope/).reply(403);
                 nock("http://persona").head(/\/oauth\/tokens\/.*\?scope=su/).reply(204);
 
@@ -513,6 +519,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             jwt.sign(payload, privateKey, jwtSigningOptions, function(token) {
                 var req = _getStubRequest(token, null);
                 var res = _getStubResponse();
+
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
                     (err === null).should.be.true;
                     assert.equal(res._statusWasCalled, false);

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -74,7 +74,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
 
         afterEach(function afterEachTest() {
             if (this.nockAssertions) {
-                lodash.forEach(this.nockAssertions, function eachNock(nockAssertion) {
+                lodash.forEach(this.nockAssertions, function verifyEachNockRequest(nockAssertion) {
                     nockAssertion.done();
                 });
             }
@@ -136,7 +136,9 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
-                    (err === null).should.be.true;
+                    if (err) {
+                        return done(err);
+                    }
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -166,7 +168,9 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
-                    (err === null).should.be.true;
+                    if (err) {
+                        return done(err);
+                    }
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -263,7 +267,9 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
-                    (err === null).should.be.true;
+                    if (err) {
+                        return done(err);
+                    }
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -328,7 +334,9 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
-                    (err === null).should.be.true;
+                    if (err) {
+                        return done(err);
+                    }
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
@@ -534,7 +542,9 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var res = _getStubResponse();
 
                 personaClient.validateHTTPBearerToken(req, res, function validatedToken(err, result) {
-                    (err === null).should.be.true;
+                    if (err) {
+                        return done(err);
+                    }
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -80,10 +80,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             // the callback wont be called internally because this is middleware
             // therefore we need to call validate token and wait a couple of seconds for the
             // request to fail and assert the response object
-            personaClient.validateHTTPBearerToken(req, res, function() {
-                done("validation passed when it should not have");
-            });
-            setTimeout(function(){
+            personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                 res._statusWasCalled.should.equal(true);
                 res._jsonWasCalled.should.equal(true);
                 res._setWasCalled.should.equal(true);
@@ -93,7 +90,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 res._json.error_description.should.equal("The token is invalid or has expired");
 
                 done();
-            }, 2000);
+            });
         });
 
         it("should validate a token without scope", function(done) {
@@ -172,10 +169,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "wibble");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function(){
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -185,7 +179,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("The supplied token is missing a required scope");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
@@ -207,10 +201,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function() {
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -220,7 +211,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("The token is invalid or has expired");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
@@ -338,10 +329,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "invalid");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function() {
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -351,7 +339,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("The supplied token is missing a required scope");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
@@ -374,10 +362,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "fatuser");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function() {
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -387,7 +372,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("The token is invalid or has expired");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
@@ -410,10 +395,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "fatuser");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function() {
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -423,7 +405,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("communication_issue");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
@@ -447,10 +429,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function(){
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -460,7 +439,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("The token is invalid or has expired");
 
                     done();
-                }, 2000);
+
+                });
             });
         });
 
@@ -482,10 +462,7 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 var req = _getStubRequest(token, "standard_user");
                 var res = _getStubResponse();
 
-                personaClient.validateHTTPBearerToken(req, res, function() {
-                    done("validation passed when it should not have");
-                });
-                setTimeout(function(){
+                personaClient.validateHTTPBearerToken(req, res, function(err, success) {
                     res._statusWasCalled.should.equal(true);
                     res._jsonWasCalled.should.equal(true);
                     res._setWasCalled.should.equal(true);
@@ -495,13 +472,11 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._json.error_description.should.equal("communication_issue");
 
                     done();
-                }, 2000);
+                });
             });
         });
 
         it("should use a cached public key when validating a token", function(done) {
-
-
             var payload = {
                 scopes: [
                     "standard_user"

--- a/test/user_profile_tests.js
+++ b/test/user_profile_tests.js
@@ -19,7 +19,8 @@ describe("Persona Client Test Suite - User Profile Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "redis": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -35,7 +36,8 @@ describe("Persona Client Test Suite - User Profile Tests", function() {
                     }
                 }
             },
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "legacy-config-options": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -45,7 +47,8 @@ describe("Persona Client Test Suite - User Profile Tests", function() {
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         }
     }, function(personaClientConfig) {
         beforeEach(function() {

--- a/test/user_scope_tests.js
+++ b/test/user_scope_tests.js
@@ -19,7 +19,8 @@ describe("Persona Client Test Suite - User Scope Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "redis": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -35,7 +36,8 @@ describe("Persona Client Test Suite - User Scope Tests", function() {
                     }
                 }
             },
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         },
         "legacy-config-options": {
             persona_host: process.env.PERSONA_TEST_HOST || "persona",
@@ -45,7 +47,8 @@ describe("Persona Client Test Suite - User Scope Tests", function() {
             redis_host: "localhost",
             redis_port: 6379,
             redis_db: 0,
-            enable_debug: false
+            enable_debug: false,
+            cert_background_refresh: false,
         }
     }, function(personaClientConfig) {
         beforeEach(function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -111,9 +111,11 @@ var beforeEach = function recordOrReplayHttpCalls(testFriendlyName, responsesFol
             dont_print: true,
             output_objects: true
         });
-    } else {
-        nock.load(__dirname + "/responses/" + responsesFolder + "/" + testName + ".json");
+
+        return null;
     }
+
+    return nock.load(__dirname + '/responses/' + responsesFolder + '/' + testName + '.json');
 };
 
 var afterEach = function recordAndSaveHttpCallsIfEnabled(testFriendlyName, responsesFolder) {


### PR DESCRIPTION
The retrieval of the Persona public key every 10 minutes is causing the response times to spike. This PR is to append a new option of retrieving the certificate in the background before it expires within the cache. In doing so the client requests will not be affected.

The auto refresh will attempt to retrieve the certificate every 9 minutes, while the cache will expire every 10 minutes. If the auto refresh fails to  retrieve the certificate the incoming requests will try again.

JFDI: remove setTimeout and make `validateHTTPBearerToken` return a error (not a api change) to make the tests more stable.

fixes https://github.com/talis/platform/issues/145

 - [x] separate bound methods to allow for updates
 - [x] add constructor option for automatic background updates
 - [x] remove setTimeout from tests