### PR TITLE
90% - No token middleware bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,7 @@ PersonaClient.prototype.validateHTTPBearerToken = function validateHTTPBearerTok
             response.set('Connection', 'close');
             response.json({
                 'error': 'unexpected_error',
-                'error_description': error,
+                'error_description': 'Unexpected error occurred',
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -413,7 +413,7 @@ PersonaClient.prototype.validateHTTPBearerToken = function validateHTTPBearerTok
             return callback(ERROR_TYPES.INVALID_TOKEN, null);
         }
 
-        throw exception;
+        return callback(exception.message, null);
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -27,17 +27,16 @@ var ERROR_TYPES = {
 
 /**
  * Validate method opts
- * @param opts 
+ * @param opts
  * @param mandatoryKeys null|array|object a simple array of madatory keys, or key/value where value is a function to validate the value of key in opts
- * @throws Error 
+ * @throws Error
  */
 var validateOpts = function validateOpts(opts, mandatoryKeys) {
     var error = new Error();
     error.name = ERROR_TYPES.INVALID_ARGUMENTS;
 
     if (!_.isObject(opts)) {
-        error.message = 'Expecting opts to be an object';
-        throw error;
+        throw new Error('Expecting opts to be an object');
     }
 
     if (_.isArray(mandatoryKeys)) {

--- a/index.js
+++ b/index.js
@@ -344,55 +344,65 @@ PersonaClient.prototype.validateToken = function (opts, next) {
  * @param {Object} response - HTTP response object. If you want to validate against a scope (pre-2.0 behavior), provide it as req.params.scope
  * @callback next - Called with either an error as the first param or "ok" as the result in the second param.
  */
-PersonaClient.prototype.validateHTTPBearerToken = function (request, response, next) {
-    if (arguments.length > 3) {
-        throw "Usage: validateHTTPBearerToken(request, response, next)";
-    }
-    var token = this._getToken(request);
-    var xRequestId = this.getXRequestId(request);
+PersonaClient.prototype.validateHTTPBearerToken = function validateHTTPBearerToken(request, response, next) {
+    var config = {
+        token: this._getToken(request),
+        scope: request.param('scope'),
+        xRequestId: this.getXRequestId(request),
+    };
 
-    this.validateToken({token: token, scope: request.param("scope"), xRequestId: xRequestId}, function (error, validationResult) {
+    if (arguments.length > 3) {
+        throw new Error('Usage: validateHTTPBearerToken(request, response, next)');
+    }
+
+    function callback(error, validationResult) {
         if (!error) {
             next(null, validationResult);
             return;
         }
 
-        switch(error) {
+        switch (error) {
         case ERROR_TYPES.INVALID_TOKEN:
             response.status(401);
             response.json({
-                "error": "no_token",
-                "error_description": "No token supplied"
+                'error': 'no_token',
+                'error_description': 'No token supplied',
             });
             break;
         case ERROR_TYPES.VALIDATION_FAILURE:
             response.status(401);
-            response.set("Connection", "close");
+            response.set('Connection', 'close');
             response.json({
-                "error": "invalid_token",
-                "error_description": "The token is invalid or has expired"
+                'error': 'invalid_token',
+                'error_description': 'The token is invalid or has expired',
             });
             break;
         case ERROR_TYPES.INSUFFICIENT_SCOPE:
             response.status(403);
-            response.set("Connection", "close");
+            response.set('Connection', 'close');
             response.json({
-                "error": "insufficient_scope",
-                "error_description": "The supplied token is missing a required scope"
+                'error': 'insufficient_scope',
+                'error_description': 'The supplied token is missing a required scope',
             });
             break;
         default:
             response.status(500);
-            response.set("Connection", "close");
+            response.set('Connection', 'close');
             response.json({
-                "error": "unexpected_error",
-                "error_description": error
+                'error': 'unexpected_error',
+                'error_description': error,
             });
         }
 
         next(error, null);
         return;
-    });
+    }
+
+    try {
+        this.validateToken(config, callback);
+    } catch (exception) {
+        return callback(ERROR_TYPES.INVALID_TOKEN, null);
+    }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -486,8 +486,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._setWasCalled.should.equal(true);
 
                     res._status.should.equal(500);
-                    res._json.error.should.equal("unexpected_error");
-                    res._json.error_description.should.equal("communication_issue");
+                    res._json.error.should.equal('unexpected_error');
+                    res._json.error_description.should.equal('Unexpected error occurred');
 
                     done();
                 });
@@ -556,8 +556,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     res._setWasCalled.should.equal(true);
 
                     res._status.should.equal(500);
-                    res._json.error.should.equal("unexpected_error");
-                    res._json.error_description.should.equal("communication_issue");
+                    res._json.error.should.equal('unexpected_error');
+                    res._json.error_description.should.equal('Unexpected error occurred');
 
                     done();
                 });


### PR DESCRIPTION
ValidateToken now throws an exception if `token` is not supplied.
The token is checked by using `_.isEmpty` (null, "", 0, etc). As the
token is supplied by the user within the middleware it is possible that
it could be null or a empty string. This will throw an exception that
is not handled correctly.