### PR TITLE
90% - Fix relative version file loading issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var CacheService = require("cache-service");
 var fs = require("fs");
 var uuid = require('uuid');
 
-var clientVer = JSON.parse(fs.readFileSync("package.json", "utf8")).version || "unknown";
+var clientVer = JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf8')).version || 'unknown';
 
 var PUBLIC_KEY_CACHE_NAME = "public_key";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",


### PR DESCRIPTION
When the base location is not within persona-node-client, loading
the package.json file fails as the path is not absolute.

Added code to load the file by it's absolute path location.