### PR TITLE
90%: Return decoded token upon successful validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",

--- a/test/token_validation_tests.js
+++ b/test/token_validation_tests.js
@@ -154,7 +154,12 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
 
-                    assert.equal(result, "ok");
+                    result.should.have.property("scopes");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopes.should.eql(["standard_user"]);
                     done();
                 });
             });
@@ -218,7 +223,12 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
 
-                    assert.equal(result, "ok");
+                    result.should.have.property("scopes");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopes.should.eql(["standard_user"]);
                     done();
                 });
             });
@@ -317,7 +327,12 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
 
-                    assert.equal(result, "ok");
+                    result.should.have.property("scopes");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopes.should.eql(["su", "super_user"]);
                     done();
                 });
             });
@@ -350,7 +365,12 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
 
-                    assert.equal(result, "ok");
+                    result.should.have.property("scopeCount");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopeCount.should.eql(26);
                     done();
                 });
             });
@@ -384,7 +404,12 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
 
-                    assert.equal(result, "ok");
+                    result.should.have.property("scopeCount");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopeCount.should.eql(26);
                     done();
                 });
             });
@@ -591,10 +616,14 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                     assert.equal(res._statusWasCalled, false);
                     assert.equal(res._jsonWasCalled, false);
                     assert.equal(res._setWasCalled, false);
-
-                    assert.equal(result, "ok");
                     assert.equal(personaClient.http.request.called, false);
 
+                    result.should.have.property("scopes");
+                    result.should.have.property("iat");
+                    result.should.have.property("exp");
+                    result.should.have.property("aud");
+                    result.should.have.property("jti");
+                    result.scopes.should.eql(["standard_user"]);
                     done();
                 });
             });


### PR DESCRIPTION
This change returns a decoded JWT upon successful validation instead of the string "ok".

This is so that metadata can be extracted and used by other services. For example, when securing an AWS API gateway route, Amazon needs to know who the token belongs to in order to create an authentication policy for the request.