### PR TITLE
Made validate token call callback with err on invalid token

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,11 @@ PersonaClient.prototype._getPublicKey = function getPublicKey(cb, refresh, xRequ
  * validating.
  */
 PersonaClient.prototype.validateToken = function (opts, next) {
-    validateOpts(opts,['token']);
+    try {
+        validateOpts(opts,['token']);
+    } catch (e) {
+        return next(ERROR_TYPES.INVALID_TOKEN, null);
+    }
     var token = opts.token;
     var scope = opts.scope;
     var xRequestId = opts.xRequestId || uuid.v4();
@@ -267,10 +271,6 @@ PersonaClient.prototype.validateToken = function (opts, next) {
         throw "No callback (next attribute) provided";
     } else if (typeof next !== "function") {
         throw "Parameter 'next' is not a function";
-    }
-
-    if (token == null) {
-        return next(ERROR_TYPES.INVALID_TOKEN, null);
     }
 
     var headScopeThenVerify = function headScope(scope, callback, decodedToken) {
@@ -417,15 +417,7 @@ PersonaClient.prototype.validateHTTPBearerToken = function validateHTTPBearerTok
         return;
     }
 
-    try {
-        this.validateToken(config, callback);
-    } catch (exception) {
-        if (exception.name === ERROR_TYPES.INVALID_ARGUMENTS) {
-            return callback(ERROR_TYPES.INVALID_TOKEN, null, null);
-        }
-
-        return callback(exception.message, null, null);
-    }
+    this.validateToken(config, callback);
 };
 
 /**


### PR DESCRIPTION
The existing `validateToken` method had unreachable code for case INVALID_TOKEN, instead it was throwing the uncaught error from `validateOps`. The express middleware wrapper caught this behaviour and called its callback with the correct error.

Instead just have `validateToken` do that in the first place.