### PR TITLE
90% - Add ability to query multiple profiles at once 

### DIFF
--- a/index.js
+++ b/index.js
@@ -929,103 +929,107 @@ PersonaClient.prototype.getProfileByGuid = function(opts, callback){
 };
 
 /**
- * Get all profiles for an array of guids.
+* Get all profiles for an array of guids.
+ *
+ * @param  {object}   opts     [description]
+ * @param  {array}    opts.guids  Array of GUIDs to fetch profiles for
+ * @param  {string}   opts.token  Auth token
+ * @param  {string}   opts.xRequestId Optional request ID to pass through in logging.
+ * @param  {Function} callback
  */
- PersonaClient.prototype.getProfilesForGuids = function(opts, callback){
-     validateOpts(opts,{guids: _.isArray,token: _.isString});
-     var guids = opts.guids;
-     var token = opts.token;
-     var xRequestId = opts.xRequestId || uuid.v4();
-     var personaQueryLimit = 25;
-     var _this = this;
-     var guidList = [];
-     var guidListArray = [];
-     // loop through passed guids and build an array of guids that will be used to query persona
-     guids.forEach(function (guid) {
-         guidList.push(guid);
-         // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
-         // reset for next lot
-         if (guidList.length === personaQueryLimit) {
-             guidListArray.push(guidList);
-             guidList = [];
-         }
-     });
-     // see if we have any guidList left that have not been pushed to the guidListArray yet, push them now if that's the case
-     if (guidList.length > 0) {
-         guidListArray.push(guidList);
-     }
-     var parallelFNs = [];
-     // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
-     // an array. Each of these functions will call Persona with a block of the users to hydrate...
-     guidListArray.forEach(function (guidList) {
-         var ids = '';
-         // generate a comma-sep list of user's from the list of users we need to process
-         guidList.forEach(function (guid) {
-             ids += (ids !== '') ? ',' + guid : guid;
-         });
-         parallelFNs.push(function (cb) {
-             var options = {
-                 hostname: _this.config.persona_host,
-                 port: _this.config.persona_port,
-                 path: "/users?guids=" + ids,
-                 method: "GET",
-                 headers: {
-                     "Authorization": "Bearer " + token,
-                     'User-Agent': _this.userAgent,
-                     'X-Request-Id': xRequestId
-                 }
-             };
-             var personaReq = _this.http.request(options, function (personaResp) {
-                 var userString = '';
-                 personaResp.on('data', function (chunk) {
-                     userString += chunk;
-                 });
-                 personaResp.on('end', function () {
-                     if (personaResp.statusCode === 200) {
-                         var data = JSON.parse(userString);
-                         var results = [];
-                         if (!_.isEmpty(data)) {
-                             if (_.isArray(data)) {
-                                 results = data;
-                             } else {
-                                 results.push(data);
-                             }
-                         }
-                         console.log('LOGGING Got results from persona, calling back...', results);
-                         cb(null, results);
-                     } else {
-                         console.log('LOGGING Got ' + personaResp.statusCode + ' while retrieving users with HTTP options: ' + JSON.stringify(options));
-                         var error = new Error();
-                         error.http_code = personaResp.statusCode || 404;
-                         cb(error, null);
-                     }
-                 });
-             });
-             personaReq.on('error', function (err) {
-                 cb(err, null);
-             });
-             personaReq.on('clientError', function (err) {
-                 cb(err, null);
-             });
-             personaReq.end();
-         });
-     });
-     // execute the functions in parallel - so all calls will be made to persona in parallel
-     async.parallel(parallelFNs, function (err, userArrays) {
-         if (err) {
-             var errMess = "getProfilesForGuids problem: " + err;
-             _this.error(errMess);
-             callback(errMess, null);
-         } else if (userArrays) {
-             // we could potentially have multiple arrays of users here, so merge them into one
-             var mergedUsers = [].concat.apply([], userArrays);
-             callback(null, mergedUsers);
-         } else {
-             callback(null, null);
-         }
-     });
+PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
+    validateOpts(opts,{guids: _.isArray,token: _.isString});
+    var guids = opts.guids;
+    var token = opts.token;
+    var xRequestId = opts.xRequestId || uuid.v4();
+    var personaQueryLimit = 25;
+    var _this = this;
+    var guidList = [];
+    var guidListArray = [];
+    // loop through passed guids and build an array of guids that will be used to query persona
+    guids.forEach(function (guid) {
+        guidList.push(guid);
+        // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
+        // reset for next lot
+        if (guidList.length === personaQueryLimit) {
+            guidListArray.push(guidList);
+            guidList = [];
+        }
+    });
+    // see if we have any guidList left that have not been pushed to the guidListArray yet, push them now if that's the case
+    if (guidList.length > 0) {
+        guidListArray.push(guidList);
+    }
+    var parallelFNs = [];
+    // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
+    // an array. Each of these functions will call Persona with a block of the users to hydrate...
+    guidListArray.forEach(function (guidList) {
+        var ids = '';
+        // generate a comma-sep list of user's from the list of users we need to process
+        guidList.forEach(function (guid) {
+            ids += (ids !== '') ? ',' + guid : guid;
+        });
+        parallelFNs.push(function pushFn(cb) {
+            var options = {
+                hostname: _this.config.persona_host,
+                port: _this.config.persona_port,
+                path: '/users?guids=' + ids,
+                method: "GET",
+                headers: {
+                    'Authorization': 'Bearer ' + token,
+                    'User-Agent': _this.userAgent,
+                    'X-Request-Id': xRequestId
+                }
+            };
+            var personaReq = _this.http.request(options, function personaReq(personaResp) {
+                var userString = '';
+                personaResp.on('data', function onData(chunk) {
+                    userString += chunk;
+                });
+                personaResp.on('end', function onEnd() {
+                    if (personaResp.statusCode === 200) {
+                        var data = JSON.parse(userString);
+                        var results = [];
+                        if (!_.isEmpty(data)) {
+                            if (_.isArray(data)) {
+                                results = data;
+                            } else {
+                                results.push(data);
+                            }
+                        }
+                        cb(null, results);
+                    } else {
+                        var error = new Error();
+                        error.http_code = personaResp.statusCode || 404;
+                        cb(error, null);
+                    }
+                });
+            });
+            personaReq.on('error', function onError(err) {
+                cb(err, null);
+            });
+            personaReq.on('clientError', function onClientError(err) {
+                cb(err, null);
+            });
+            personaReq.end();
+        });
+    });
+    // execute the functions in parallel - so all calls will be made to persona in parallel
+    async.parallel(parallelFNs, function (err, userArrays) {
+        if (err) {
+            var errMess = 'getProfilesForGuids problem: ' + err;
+            _this.error(errMess);
+            callback(errMess, null);
+        } else if (userArrays) {
+            // we could potentially have multiple arrays of users here, so merge them into one
+            var mergedUsers = [].concat.apply([], userArrays);
+            callback(null, mergedUsers);
+        } else {
+            callback(null, null);
+        }
+    });
  };
- 
+
 /**
  * Removes any tokens that are cached for the given id and secret
  * @param id

--- a/index.js
+++ b/index.js
@@ -931,101 +931,101 @@ PersonaClient.prototype.getProfileByGuid = function(opts, callback){
 /**
  * Get all profiles for an array of guids.
  */
-PersonaClient.prototype.getProfilesForGuids = function(opts, callback){
-    validateOpts(opts,{guids: _.isArray,token: _.isString});
-    var guids = opts.guids;
-    var token = opts.token;
-    var xRequestId = opts.xRequestId || uuid.v4();
-    var personaQueryLimit = 25;
-    var _this = this;
-    var guidList = [];
-    var guidListArray = [];
-    // loop through passed guids and build an array of guids that will be used to query persona
-    guids.forEach(function (guid) {
-        guidList.push(guid);
-        // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
-        // reset for next lot
-        if (guidList.length === personaQueryLimit) {
-            guidListArray.push(guidList);
-            guidList = [];
-        }
-    });
-    // see if we have any guidList left that have not been pushed to the guidListArray yet, push them now if that's the case
-    if (guidList.length > 0) {
-        guidListArray.push(guidList);
-    }
-    var parallelFNs = [];
-    // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
-    // an array. Each of these functions will call Persona with a block of the users to hydrate...
-    guidListArray.forEach(function (guidList) {
-        var ids = '';
-        // generate a comma-sep list of user's from the list of users we need to process
-        guidList.forEach(function (guid) {
-            ids += (ids !== '') ? ',' + guid : guid;
-        });
-        parallelFNs.push(function (cb) {
-            var options = {
-                hostname: _this.config.persona_host,
-                port: _this.config.persona_port,
-                path: "/users?guids=" + ids,
-                method: "GET",
-                headers: {
-                    "Authorization": "Bearer " + token,
-                    'User-Agent': _this.userAgent,
-                    'X-Request-Id': xRequestId
-                }
-            };
-            var personaReq = _this.http.request(options, function (personaResp) {
-                var userString = '';
-                personaResp.on('data', function (chunk) {
-                    userString += chunk;
-                });
-                personaResp.on('end', function () {
-                    if (personaResp.statusCode === 200) {
-                        var data = JSON.parse(userString);
-                        var results = [];
-                        if (!_.isEmpty(data)) {
-                            if (_.isArray(data)) {
-                                results = data;
-                            } else {
-                                results.push(data);
-                            }
-                        }
-                        console.log('LOGGING Got results from persona, calling back...', results);
-                        cb(null, results);
-                    } else {
-                        console.log('LOGGING Got ' + personaResp.statusCode + ' while retrieving users with HTTP options: ' + JSON.stringify(options));
-                        var error = new Error();
-                        error.http_code = personaResp.statusCode || 404;
-                        cb(error, null);
-                    }
-                });
-            });
-            personaReq.on('error', function (err) {
-                cb(err, null);
-            });
-            personaReq.on('clientError', function (err) {
-                cb(err, null);
-            });
-            personaReq.end();
-        });
-    });
-    // execute the functions in parallel - so all calls will be made to persona in parallel
-    async.parallel(parallelFNs, function (err, userArrays) {
-        if (err) {
-            var errMess = "getProfilesForGuids problem: " + err;
-            _this.error(errMess);
-            callback(errMess, null);
-        } else if (userArrays) {
-            // we could potentially have multiple arrays of users here, so merge them into one
-            var mergedUsers = [].concat.apply([], userArrays);
-            callback(null, mergedUsers);
-        } else {
-            callback(null, null);
-        }
-    });
-};
-
+ PersonaClient.prototype.getProfilesForGuids = function(opts, callback){
+     validateOpts(opts,{guids: _.isArray,token: _.isString});
+     var guids = opts.guids;
+     var token = opts.token;
+     var xRequestId = opts.xRequestId || uuid.v4();
+     var personaQueryLimit = 25;
+     var _this = this;
+     var guidList = [];
+     var guidListArray = [];
+     // loop through passed guids and build an array of guids that will be used to query persona
+     guids.forEach(function (guid) {
+         guidList.push(guid);
+         // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
+         // reset for next lot
+         if (guidList.length === personaQueryLimit) {
+             guidListArray.push(guidList);
+             guidList = [];
+         }
+     });
+     // see if we have any guidList left that have not been pushed to the guidListArray yet, push them now if that's the case
+     if (guidList.length > 0) {
+         guidListArray.push(guidList);
+     }
+     var parallelFNs = [];
+     // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
+     // an array. Each of these functions will call Persona with a block of the users to hydrate...
+     guidListArray.forEach(function (guidList) {
+         var ids = '';
+         // generate a comma-sep list of user's from the list of users we need to process
+         guidList.forEach(function (guid) {
+             ids += (ids !== '') ? ',' + guid : guid;
+         });
+         parallelFNs.push(function (cb) {
+             var options = {
+                 hostname: _this.config.persona_host,
+                 port: _this.config.persona_port,
+                 path: "/users?guids=" + ids,
+                 method: "GET",
+                 headers: {
+                     "Authorization": "Bearer " + token,
+                     'User-Agent': _this.userAgent,
+                     'X-Request-Id': xRequestId
+                 }
+             };
+             var personaReq = _this.http.request(options, function (personaResp) {
+                 var userString = '';
+                 personaResp.on('data', function (chunk) {
+                     userString += chunk;
+                 });
+                 personaResp.on('end', function () {
+                     if (personaResp.statusCode === 200) {
+                         var data = JSON.parse(userString);
+                         var results = [];
+                         if (!_.isEmpty(data)) {
+                             if (_.isArray(data)) {
+                                 results = data;
+                             } else {
+                                 results.push(data);
+                             }
+                         }
+                         console.log('LOGGING Got results from persona, calling back...', results);
+                         cb(null, results);
+                     } else {
+                         console.log('LOGGING Got ' + personaResp.statusCode + ' while retrieving users with HTTP options: ' + JSON.stringify(options));
+                         var error = new Error();
+                         error.http_code = personaResp.statusCode || 404;
+                         cb(error, null);
+                     }
+                 });
+             });
+             personaReq.on('error', function (err) {
+                 cb(err, null);
+             });
+             personaReq.on('clientError', function (err) {
+                 cb(err, null);
+             });
+             personaReq.end();
+         });
+     });
+     // execute the functions in parallel - so all calls will be made to persona in parallel
+     async.parallel(parallelFNs, function (err, userArrays) {
+         if (err) {
+             var errMess = "getProfilesForGuids problem: " + err;
+             _this.error(errMess);
+             callback(errMess, null);
+         } else if (userArrays) {
+             // we could potentially have multiple arrays of users here, so merge them into one
+             var mergedUsers = [].concat.apply([], userArrays);
+             callback(null, mergedUsers);
+         } else {
+             callback(null, null);
+         }
+     });
+ };
+ 
 /**
  * Removes any tokens that are cached for the given id and secret
  * @param id

--- a/index.js
+++ b/index.js
@@ -937,8 +937,8 @@ PersonaClient.prototype.getProfileByGuid = function(opts, callback){
  * @param  {string}   opts.xRequestId Optional request ID to pass through in logging.
  * @param  {Function} callback
  */
-PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
-    validateOpts(opts,{guids: _.isArray,token: _.isString});
+PersonaClient.prototype.getProfilesForGuids = function getProfilesForGuids(opts, callback) {
+    validateOpts(opts,{ guids: _.isArray, token: _.isString });
     var guids = opts.guids;
     var token = opts.token;
     var xRequestId = opts.xRequestId || uuid.v4();
@@ -953,7 +953,7 @@ PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
     var personaParallelLimit = 10;
 
     // loop through passed guids and build an array of guids that will be used to query persona
-    guids.forEach(function (guid) {
+    guids.forEach(function eachGuid(guid) {
         guidList.push(guid);
         // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
         // reset for next lot
@@ -969,7 +969,7 @@ PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
     var parallelFNs = [];
     // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
     // an array. Each of these functions will call Persona with a block of the users to hydrate...
-    guidListArray.forEach(function (guidList) {
+    guidListArray.forEach(function eachGuidList(guidList) {
         var ids = '';
         // generate a comma-sep list of user's from the list of users we need to process
         guidList.forEach(function (guid) {
@@ -980,7 +980,7 @@ PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
                 hostname: _this.config.persona_host,
                 port: _this.config.persona_port,
                 path: '/users?guids=' + ids,
-                method: "GET",
+                method: 'GET',
                 headers: {
                     'Authorization': 'Bearer ' + token,
                     'User-Agent': _this.userAgent,
@@ -997,11 +997,11 @@ PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
                         var data = JSON.parse(userString);
                         var results = [];
                         if (!_.isEmpty(data)) {
-                            if (_.isArray(data)) {
+                            if (_.isArray(data)) {
                                 results = data;
-                            } else {
-                                results.push(data);
-                            }
+                            } else {
+                                results.push(data);
+                            }
                         }
                         cb(null, results);
                     } else {
@@ -1011,12 +1011,10 @@ PersonaClient.prototype.getProfilesForGuids = function(opts, callback) {
                     }
                 });
             });
-            personaReq.on('error', function onError(err) {
-                cb(err, null);
-            });
-            personaReq.on('clientError', function onClientError(err) {
-                cb(err, null);
-            });
+
+            personaReq.on('error', cb);
+            personaReq.on('clientError', cb);
+
             personaReq.end();
         });
     });

--- a/index.js
+++ b/index.js
@@ -940,17 +940,13 @@ PersonaClient.prototype.getProfileByGuid = function(opts, callback){
  */
 PersonaClient.prototype.getProfilesForGuids = function getProfilesForGuids(opts, callback) {
     validateOpts(opts,{ guids: _.isArray, token: _.isString });
+    var log = this.log.bind(this);
     var guids = opts.guids;
     var token = opts.token;
     var xRequestId = opts.xRequestId || uuid.v4();
     var _this = this;
 
-    var ids = '';
-
-    // generate a comma-sep list of user's from the list of users we need to process
-    guids.forEach(function (guid) {
-        ids += (ids !== '') ? ',' + guid : guid;
-    });
+    var ids = guids.join(',');
 
     var options = {
         hostname: _this.config.persona_host,
@@ -985,7 +981,9 @@ PersonaClient.prototype.getProfilesForGuids = function getProfilesForGuids(opts,
                 callback(null, results);
             } else {
                 var error = new Error();
-                error.http_code = personaResp.statusCode || 404;
+                var statusCode = personaResp.statusCode || 0;
+                error.http_code = statusCode;
+                log('error', 'getProfilesForGuids failed with status code ' + statusCode);
                 callback(error, null);
             }
         });

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var jwt = require("jsonwebtoken");
 var CacheService = require("cache-service");
 var fs = require("fs");
 var uuid = require('uuid');
+var async = require('async');
 
 var clientVer = JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf8')).version || 'unknown';
 
@@ -926,6 +927,105 @@ PersonaClient.prototype.getProfileByGuid = function(opts, callback){
     });
     req.end();
 };
+
+/**
+ * Get all profiles for an array of guids.
+ */
+PersonaClient.prototype.getProfilesForGuids = function(opts, callback){
+    validateOpts(opts,{guids: _.isArray,token: _.isString});
+    var guids = opts.guids;
+    var token = opts.token;
+    var xRequestId = opts.xRequestId || uuid.v4();
+    var personaQueryLimit = 25;
+    var _this = this;
+    var guidList = [];
+    var guidListArray = [];
+    // loop through passed guids and build an array of guids that will be used to query persona
+    guids.forEach(function (guid) {
+        guidList.push(guid);
+        // if we've collected personaQueryLimit guids in the current guidList array, push it onto the guidListArray and
+        // reset for next lot
+        if (guidList.length === personaQueryLimit) {
+            guidListArray.push(guidList);
+            guidList = [];
+        }
+    });
+    // see if we have any guidList left that have not been pushed to the guidListArray yet, push them now if that's the case
+    if (guidList.length > 0) {
+        guidListArray.push(guidList);
+    }
+    var parallelFNs = [];
+    // for each of the "blocks" of users we want to hydrate, create a parallel function and add it to
+    // an array. Each of these functions will call Persona with a block of the users to hydrate...
+    guidListArray.forEach(function (guidList) {
+        var ids = '';
+        // generate a comma-sep list of user's from the list of users we need to process
+        guidList.forEach(function (guid) {
+            ids += (ids !== '') ? ',' + guid : guid;
+        });
+        parallelFNs.push(function (cb) {
+            var options = {
+                hostname: _this.config.persona_host,
+                port: _this.config.persona_port,
+                path: "/users?guids=" + ids,
+                method: "GET",
+                headers: {
+                    "Authorization": "Bearer " + token,
+                    'User-Agent': _this.userAgent,
+                    'X-Request-Id': xRequestId
+                }
+            };
+            var personaReq = _this.http.request(options, function (personaResp) {
+                var userString = '';
+                personaResp.on('data', function (chunk) {
+                    userString += chunk;
+                });
+                personaResp.on('end', function () {
+                    if (personaResp.statusCode === 200) {
+                        var data = JSON.parse(userString);
+                        var results = [];
+                        if (!_.isEmpty(data)) {
+                            if (_.isArray(data)) {
+                                results = data;
+                            } else {
+                                results.push(data);
+                            }
+                        }
+                        console.log('LOGGING Got results from persona, calling back...', results);
+                        cb(null, results);
+                    } else {
+                        console.log('LOGGING Got ' + personaResp.statusCode + ' while retrieving users with HTTP options: ' + JSON.stringify(options));
+                        var error = new Error();
+                        error.http_code = personaResp.statusCode || 404;
+                        cb(error, null);
+                    }
+                });
+            });
+            personaReq.on('error', function (err) {
+                cb(err, null);
+            });
+            personaReq.on('clientError', function (err) {
+                cb(err, null);
+            });
+            personaReq.end();
+        });
+    });
+    // execute the functions in parallel - so all calls will be made to persona in parallel
+    async.parallel(parallelFNs, function (err, userArrays) {
+        if (err) {
+            var errMess = "getProfilesForGuids problem: " + err;
+            _this.error(errMess);
+            callback(errMess, null);
+        } else if (userArrays) {
+            // we could potentially have multiple arrays of users here, so merge them into one
+            var mergedUsers = [].concat.apply([], userArrays);
+            callback(null, mergedUsers);
+        } else {
+            callback(null, null);
+        }
+    });
+};
+
 /**
  * Removes any tokens that are cached for the given id and secret
  * @param id
@@ -1177,4 +1277,3 @@ exports.errorTypes = ERROR_TYPES;
 exports.createClient = function (appUA,config) {
     return new PersonaClient(appUA,config);
 };
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",


### PR DESCRIPTION
TN requires the ability to query multiple profiles at once.  Persona node client currently seems somewhat lacking in support for the Persona Server API calls so this branch just adds one that we immediately need.  I intend to raise another ticket against persona-node-client to request better querying abilities and support of the persona server api when time allows.