### PR TITLE
90% - bump version of cache-service-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",
@@ -37,7 +37,7 @@
     "async": "~0.2.9",
     "cache-service": "~1.3.5",
     "cache-service-node-cache": "^1.1.1",
-    "cache-service-redis": "^1.1.3",
+    "cache-service-redis": "^1.2.3",
     "crypto-js": "3.1.2-2",
     "jsonwebtoken": "~5.7.0",
     "lodash": "3.10.1",


### PR DESCRIPTION
Due to a suspected change in the version of Redis used by the cache service library, we are seeing deprecation messages when TN starts related to AUTH params being passed to Redis from the cache service library when no AUTH params have been set.

Note that there are 2 messages output:

"node_redis: Deprecated: The AUTH command contains a "undefined" argument."
and
"node_redis: Warning: Redis server does not require a password, but a password was supplied."

See this issue: 

https://github.com/talis/talis.com-app/issues/840

This PR bumps the version of the `cache-service-redis` used by the cache service library in Persona node client.

I raised a PR against the library and the maintainer accepted it and built a new version. See here: https://github.com/jpodwys/cache-service-redis/issues/11