### PR TITLE
90% - Remove config of persona_oauth_route

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ var hashKey = function hashKey(key) {
  * config.persona_host = string, defaults to "users.talis.com";
  * config.persona_port = string|integer, defaults to 443;
  * config.persona_scheme = string, defaults to "https";
- * config.persona_oauth_route = string, defaults to "/oauth/tokens/";
  * config.enable_debug : true|false
  * config.logger: <pass in a logger that has debug() and error() functions>
  * config.cache: { module: <redis|node-cache>, options: <cache-service-options> }
@@ -136,8 +135,9 @@ var PersonaClient = function (appUA, config) {
         persona_host: "users.talis.com",
         persona_port: 443,
         persona_scheme: "https",
-        persona_oauth_route: "/oauth/tokens/"
     },this.config);
+
+    this.config.persona_oauth_route = '/oauth/tokens';
 
     var CacheServiceModule;
     var cacheOptions = {};
@@ -320,7 +320,7 @@ PersonaClient.prototype.validateToken = function (opts, next) {
         var options = {
             hostname: this.config.persona_host,
             port: this.config.persona_port,
-            path: API_VERSION_PREFIX + this.config.persona_oauth_route + token + queryParams,
+            path: API_VERSION_PREFIX + this.config.persona_oauth_route + '/' + token + queryParams,
             method: "HEAD",
             headers: {
                 'User-Agent': this.userAgent,
@@ -617,7 +617,7 @@ PersonaClient.prototype.obtainToken = function (opts, callback) {
                         hostname: _this.config.persona_host,
                         port: _this.config.persona_port,
                         auth: id + ":" + secret,
-                        path: API_VERSION_PREFIX + '/oauth/tokens',
+                        path: API_VERSION_PREFIX + this.config.persona_oauth_route,
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/x-www-form-urlencoded',

--- a/index.js
+++ b/index.js
@@ -703,8 +703,7 @@ PersonaClient.prototype.obtainToken = function (opts, callback) {
                 });
             }
         }
-    });
-
+    }.bind(this));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persona_client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Persona, repsonsible for retrieving, generating, caching and validating OAuth Tokens.",


### PR DESCRIPTION
> Version 4 of the persona node client forced all the routes to use the version 3 API routes in Persona. As part of this change, the HEAD token request still uses config.persona_oauth_route but prefixed with the API version. Any consumers of the client who set the config.persona_oauth_route add the version to this and so you end up with /3/3/oauth/tokens which causes a 404.

fixes https://github.com/talis/platform/issues/1417