### PR TITLE
PLAT-6839 Updating hashing algorithm to md5 so we can support node 18

### DIFF
--- a/client/lib/hash-key.js
+++ b/client/lib/hash-key.js
@@ -1,14 +1,14 @@
 var crypto = require('crypto');
 
 /**
- * Hash a key using md4 & base64 encoding. Md4 is used as the implementation
+ * Hash a key using md5 & base64 encoding. Md4 is used as the implementation
  * in node is the fastest hashing alg supported.
  * @param {string} key value to hash
  * @return {string} hashed key
  */
 var hashKey = function hashKey(key) {
     return crypto
-        .createHash('md4')
+        .createHash('md5')
         .update(key)
         .digest('base64');
 };


### PR DESCRIPTION
Similar to https://github.com/talis/talis-node/pull/33 for talis node.

persona-node-client doesn't currently work with any version of node higher than 16, this is because it relies on md4 hashing to generate hash keys, but support for this was dropped in OpenSSL 3.0 which is included with node 17+

This PR bumps it to md5 which is still supported. 